### PR TITLE
Improve audience enforcement and logging safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.2.1] - 2025-09-21
+
+### Changed
+- Simplify `with_required_audience!` to always raise `Verikloak::Error`, letting the shared handler render forbidden responses
+
+### Fixed
+- Ensure the 500 JSON renderer logs exceptions against the actual Rails logger even when wrapped by tagged logging adapters
+
+### Documentation
+- Describe the `rescue_pundit` configuration flag and default initializer settings
+
 ## [0.2.0] - 2025-09-14
 
 ### Breaking

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    verikloak-rails (0.2.0)
+    verikloak-rails (0.2.1)
       rails (>= 6.1, < 9.0)
       verikloak (>= 0.1.2, < 0.2)
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Then configure `config/initializers/verikloak.rb`.
 | `current_user_claims` | Verified JWT claims (string keys) | `Hash` or `nil` | — |
 | `current_subject` | Convenience accessor for `sub` claim | `String` or `nil` | — |
 | `current_token` | Raw Bearer token from the request | `String` or `nil` | — |
-| `with_required_audience!(*aud)` | Enforce that `aud` includes all required entries | `void` | Renders standardized 403 JSON when requirements are not met |
+| `with_required_audience!(*aud)` | Enforce that `aud` includes all required entries | `void` | Raises `Verikloak::Error('forbidden')` so the concern renders standardized 403 JSON and halts the action |
 
 ### Data Sources
 | Value | Rack env keys | Fallback (RequestStore) | Notes |
@@ -110,7 +110,7 @@ Keys under `config.verikloak`:
 | `logger_tags` | Array<Symbol> | Tags to add to Rails logs. Supports `:request_id`, `:sub` | `[:request_id, :sub]` |
 | `error_renderer` | Object responding to `render(controller, error)` | Override error rendering | built-in JSON renderer |
 | `auto_include_controller` | Boolean | Auto-include controller concern | `true` |
-| `render_500_json` | Boolean | Rescue `StandardError` and render JSON 500 | `false` |
+| `render_500_json` | Boolean | Rescue `StandardError`, log the exception, and render JSON 500 | `false` |
 | `rescue_pundit` | Boolean | Rescue `Pundit::NotAuthorizedError` to 403 JSON when Pundit is present | `true` |
 
 Environment variable examples are in the generated initializer.

--- a/lib/verikloak/rails/configuration.rb
+++ b/lib/verikloak/rails/configuration.rb
@@ -35,11 +35,16 @@ module Verikloak
     # @!attribute [rw] render_500_json
     #   Rescue StandardError and render a JSON 500 response.
     #   @return [Boolean]
+    # @!attribute [rw] rescue_pundit
+    #   Rescue `Pundit::NotAuthorizedError` and render JSON 403 responses.
+    #   @return [Boolean]
     class Configuration
       attr_accessor :discovery_url, :audience, :issuer, :leeway, :skip_paths,
                     :logger_tags, :error_renderer, :auto_include_controller,
                     :render_500_json, :rescue_pundit
 
+      # Initialize configuration with sensible defaults for Rails apps.
+      # @return [void]
       def initialize
         @discovery_url = nil
         @audience      = nil

--- a/lib/verikloak/rails/version.rb
+++ b/lib/verikloak/rails/version.rb
@@ -2,6 +2,6 @@
 
 module Verikloak
   module Rails
-    VERSION = '0.2.0'
+    VERSION = '0.2.1'
   end
 end


### PR DESCRIPTION
## Summary
- halt controller actions by raising a forbidden Verikloak error when audience checks fail and sanitize subject log tags
- log rescued StandardError exceptions before emitting the generic 500 JSON response and document the behavior
- extend integration tests to cover logging, audience enforcement flow, and newline sanitization