### PR TITLE
Support BFF auto middleware and configurable ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
-## [Unreleased]
-
-- Nothing yet.
+---
 
 ## [0.2.2] - 2025-09-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [Unreleased]
+
+### Added
+- Automatically insert `Verikloak::Bff::HeaderGuard` when the optional gem is available, with configuration toggles and ordering controls.
+- Configuration knobs for positioning the base `Verikloak::Middleware` within the Rack stack.
+
+### Changed
+- Disable the built-in Pundit rescue when `verikloak-pundit` is loaded unless explicitly configured.
+
+### Documentation
+- Note related gems in the installer output and README, including new configuration options for middleware ordering and BFF auto-insertion.
+
 ---
 
 ## [0.2.1] - 2025-09-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Nothing yet.
+
+## [0.2.2] - 2025-09-21
+
 ### Added
 - Automatically insert `Verikloak::Bff::HeaderGuard` when the optional gem is available, with configuration toggles and ordering controls.
 - Configuration knobs for positioning the base `Verikloak::Middleware` within the Rack stack.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,6 +142,8 @@ GEM
     nio4r (2.7.4)
     nokogiri (1.18.9-aarch64-linux-musl)
       racc (~> 1.4)
+    nokogiri (1.18.9-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.18.9-x86_64-linux-musl)
       racc (~> 1.4)
     parallel (1.27.0)
@@ -266,6 +268,7 @@ GEM
 
 PLATFORMS
   aarch64-linux-musl
+  arm64-darwin-24
   x86_64-linux-musl
 
 DEPENDENCIES

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     verikloak-rails (0.2.2)
       rails (>= 6.1, < 9.0)
-      verikloak (>= 0.1.2, < 0.2)
+      verikloak (>= 0.1.5, < 1.0.0)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    verikloak-rails (0.2.1)
+    verikloak-rails (0.2.2)
       rails (>= 6.1, < 9.0)
       verikloak (>= 0.1.2, < 0.2)
 
@@ -102,6 +102,8 @@ GEM
       logger
     faraday-net_http (3.4.1)
       net-http (>= 0.5.0)
+    faraday-retry (2.3.2)
+      faraday (~> 2.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.7)
@@ -256,10 +258,11 @@ GEM
     unicode-emoji (4.0.4)
     uri (1.0.3)
     useragent (0.16.11)
-    verikloak (0.1.2)
+    verikloak (0.1.5)
       faraday (>= 2.0, < 3.0)
+      faraday-retry (>= 2.0, < 3.0)
       json (~> 2.6)
-      jwt (~> 2.7)
+      jwt (>= 2.7, < 4.0)
     websocket-driver (0.8.0)
       base64
       websocket-extensions (>= 0.1.0)

--- a/lib/generators/verikloak/install/install_generator.rb
+++ b/lib/generators/verikloak/install/install_generator.rb
@@ -30,6 +30,8 @@ module Verikloak
           2) Set discovery_url / audience in config/initializers/verikloak.rb
           3) (Optional) If you disable auto-include, add this line to ApplicationController:
                include Verikloak::Rails::Controller
+          4) (Optional) For BFF/proxy setups, add gem 'verikloak-bff' to normalize headers.
+          5) (Optional) When using Pundit policies, consider gem 'verikloak-pundit' for richer errors.
         MSG
       end
     end

--- a/lib/verikloak/rails/configuration.rb
+++ b/lib/verikloak/rails/configuration.rb
@@ -38,10 +38,28 @@ module Verikloak
     # @!attribute [rw] rescue_pundit
     #   Rescue `Pundit::NotAuthorizedError` and render JSON 403 responses.
     #   @return [Boolean]
+    # @!attribute [rw] middleware_insert_before
+    #   Rack middleware to insert `Verikloak::Middleware` before.
+    #   @return [Object, String, Symbol, nil]
+    # @!attribute [rw] middleware_insert_after
+    #   Rack middleware to insert `Verikloak::Middleware` after.
+    #   @return [Object, String, Symbol, nil]
+    # @!attribute [rw] auto_insert_bff_header_guard
+    #   Auto-insert `Verikloak::Bff::HeaderGuard` when available.
+    #   @return [Boolean]
+    # @!attribute [rw] bff_header_guard_insert_before
+    #   Rack middleware to insert the header guard before.
+    #   @return [Object, String, Symbol, nil]
+    # @!attribute [rw] bff_header_guard_insert_after
+    #   Rack middleware to insert the header guard after.
+    #   @return [Object, String, Symbol, nil]
     class Configuration
       attr_accessor :discovery_url, :audience, :issuer, :leeway, :skip_paths,
                     :logger_tags, :error_renderer, :auto_include_controller,
-                    :render_500_json, :rescue_pundit
+                    :render_500_json, :rescue_pundit,
+                    :middleware_insert_before, :middleware_insert_after,
+                    :auto_insert_bff_header_guard,
+                    :bff_header_guard_insert_before, :bff_header_guard_insert_after
 
       # Initialize configuration with sensible defaults for Rails apps.
       # @return [void]
@@ -56,6 +74,11 @@ module Verikloak
         @auto_include_controller = true
         @render_500_json = false
         @rescue_pundit = true
+        @middleware_insert_before = nil
+        @middleware_insert_after = nil
+        @auto_insert_bff_header_guard = true
+        @bff_header_guard_insert_before = nil
+        @bff_header_guard_insert_after = nil
       end
 
       # Options forwarded to the base Verikloak Rack middleware.

--- a/lib/verikloak/rails/railtie.rb
+++ b/lib/verikloak/rails/railtie.rb
@@ -16,37 +16,54 @@ module Verikloak
       # Apply configuration and insert middleware.
       # @return [void]
       initializer 'verikloak.configure' do |app|
-        Verikloak::Rails.configure do |c|
-          rails_cfg = app.config.verikloak
-          %i[discovery_url audience issuer leeway skip_paths
-             logger_tags error_renderer auto_include_controller
-             render_500_json rescue_pundit middleware_insert_before
-             middleware_insert_after auto_insert_bff_header_guard
-             bff_header_guard_insert_before bff_header_guard_insert_after].each do |key|
-            c.send("#{key}=", rails_cfg[key]) if rails_cfg.key?(key)
-          end
-          if !rails_cfg.key?(:rescue_pundit) && defined?(::Verikloak::Pundit)
-            c.rescue_pundit = false
-          end
+        stack = ::Verikloak::Rails::Railtie.send(:configure_middleware, app)
+        ::Verikloak::Rails::Railtie.send(:configure_bff_guard, stack)
+      end
+
+      # Optionally include the controller concern when ActionController loads.
+      # @return [void]
+      initializer 'verikloak.controller' do |_app|
+        ActiveSupport.on_load(:action_controller_base) do
+          include Verikloak::Rails::Controller if Verikloak::Rails.config.auto_include_controller
         end
-        base_options = Verikloak::Rails.config.middleware_options
-        stack = app.middleware
-        if (before = Verikloak::Rails.config.middleware_insert_before)
-          stack.insert_before before,
-                               ::Verikloak::Middleware,
-                               **base_options
-        else
-          after = Verikloak::Rails.config.middleware_insert_after || ::Rails::Rack::Logger
-          if after
-            stack.insert_after after,
-                               ::Verikloak::Middleware,
-                               **base_options
+      end
+
+      class << self
+        private
+
+        # Apply configured options and insert the base middleware into the stack.
+        #
+        # @param app [Rails::Application] application being initialized
+        # @return [ActionDispatch::MiddlewareStackProxy] configured middleware stack
+        def configure_middleware(app)
+          apply_configuration(app)
+          base_options = Verikloak::Rails.config.middleware_options
+          stack = app.middleware
+          if (before = Verikloak::Rails.config.middleware_insert_before)
+            stack.insert_before before,
+                                ::Verikloak::Middleware,
+                                **base_options
           else
-            stack.use ::Verikloak::Middleware, **base_options
+            after = Verikloak::Rails.config.middleware_insert_after || ::Rails::Rack::Logger
+            if after
+              stack.insert_after after,
+                                 ::Verikloak::Middleware,
+                                 **base_options
+            else
+              stack.use ::Verikloak::Middleware, **base_options
+            end
           end
+          stack
         end
 
-        if Verikloak::Rails.config.auto_insert_bff_header_guard && defined?(::Verikloak::Bff::HeaderGuard)
+        # Insert the optional HeaderGuard middleware when verikloak-bff is present.
+        #
+        # @param stack [ActionDispatch::MiddlewareStackProxy]
+        # @return [void]
+        def configure_bff_guard(stack)
+          return unless Verikloak::Rails.config.auto_insert_bff_header_guard
+          return unless defined?(::Verikloak::Bff::HeaderGuard)
+
           guard_before = Verikloak::Rails.config.bff_header_guard_insert_before
           guard_after = Verikloak::Rails.config.bff_header_guard_insert_after
           if guard_before
@@ -57,13 +74,23 @@ module Verikloak
             stack.insert_before ::Verikloak::Middleware, ::Verikloak::Bff::HeaderGuard
           end
         end
-      end
 
-      # Optionally include the controller concern when ActionController loads.
-      # @return [void]
-      initializer 'verikloak.controller' do |_app|
-        ActiveSupport.on_load(:action_controller_base) do
-          include Verikloak::Rails::Controller if Verikloak::Rails.config.auto_include_controller
+        # Sync configuration from the Rails application into Verikloak::Rails.
+        #
+        # @param app [Rails::Application]
+        # @return [void]
+        def apply_configuration(app)
+          Verikloak::Rails.configure do |c|
+            rails_cfg = app.config.verikloak
+            %i[discovery_url audience issuer leeway skip_paths
+               logger_tags error_renderer auto_include_controller
+               render_500_json rescue_pundit middleware_insert_before
+               middleware_insert_after auto_insert_bff_header_guard
+               bff_header_guard_insert_before bff_header_guard_insert_after].each do |key|
+              c.send("#{key}=", rails_cfg[key]) if rails_cfg.key?(key)
+            end
+            c.rescue_pundit = false if !rails_cfg.key?(:rescue_pundit) && defined?(::Verikloak::Pundit)
+          end
         end
       end
     end

--- a/lib/verikloak/rails/railtie.rb
+++ b/lib/verikloak/rails/railtie.rb
@@ -20,13 +20,43 @@ module Verikloak
           rails_cfg = app.config.verikloak
           %i[discovery_url audience issuer leeway skip_paths
              logger_tags error_renderer auto_include_controller
-             render_500_json rescue_pundit].each do |key|
+             render_500_json rescue_pundit middleware_insert_before
+             middleware_insert_after auto_insert_bff_header_guard
+             bff_header_guard_insert_before bff_header_guard_insert_after].each do |key|
             c.send("#{key}=", rails_cfg[key]) if rails_cfg.key?(key)
           end
+          if !rails_cfg.key?(:rescue_pundit) && defined?(::Verikloak::Pundit)
+            c.rescue_pundit = false
+          end
         end
-        app.middleware.insert_after ::Rails::Rack::Logger,
-                                    ::Verikloak::Middleware,
-                                    **Verikloak::Rails.config.middleware_options
+        base_options = Verikloak::Rails.config.middleware_options
+        stack = app.middleware
+        if (before = Verikloak::Rails.config.middleware_insert_before)
+          stack.insert_before before,
+                               ::Verikloak::Middleware,
+                               **base_options
+        else
+          after = Verikloak::Rails.config.middleware_insert_after || ::Rails::Rack::Logger
+          if after
+            stack.insert_after after,
+                               ::Verikloak::Middleware,
+                               **base_options
+          else
+            stack.use ::Verikloak::Middleware, **base_options
+          end
+        end
+
+        if Verikloak::Rails.config.auto_insert_bff_header_guard && defined?(::Verikloak::Bff::HeaderGuard)
+          guard_before = Verikloak::Rails.config.bff_header_guard_insert_before
+          guard_after = Verikloak::Rails.config.bff_header_guard_insert_after
+          if guard_before
+            stack.insert_before guard_before, ::Verikloak::Bff::HeaderGuard
+          elsif guard_after
+            stack.insert_after guard_after, ::Verikloak::Bff::HeaderGuard
+          else
+            stack.insert_before ::Verikloak::Middleware, ::Verikloak::Bff::HeaderGuard
+          end
+        end
       end
 
       # Optionally include the controller concern when ActionController loads.

--- a/lib/verikloak/rails/version.rb
+++ b/lib/verikloak/rails/version.rb
@@ -2,6 +2,6 @@
 
 module Verikloak
   module Rails
-    VERSION = '0.2.1'
+    VERSION = '0.2.2'
   end
 end

--- a/spec/integration/rails_integration_spec.rb
+++ b/spec/integration/rails_integration_spec.rb
@@ -108,6 +108,10 @@ end
 RSpec.describe 'Rails integration', type: :request do
   include Rack::Test::Methods
 
+  before do
+    Verikloak::Rails.instance_variable_set(:@config, nil)
+  end
+
   def app
     @app ||= begin
       TestApp.initialize! unless TestApp.initialized?

--- a/spec/railtie_spec.rb
+++ b/spec/railtie_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+require 'active_support/ordered_options'
+require 'rails/railtie'
+require 'rails/rack/logger'
+
+$LOAD_PATH.unshift File.expand_path('stubs', __dir__)
+require 'verikloak/middleware'
+
+require 'verikloak/rails'
+
+RSpec.describe Verikloak::Rails::Railtie do
+  before do
+    Verikloak::Rails.instance_variable_set(:@config, nil)
+  end
+
+  let(:configure_initializer) do
+    described_class.initializers.find { |i| i.name == 'verikloak.configure' }
+  end
+
+  class FakeMiddlewareStack
+    attr_reader :operations
+
+    def initialize
+      @operations = []
+    end
+
+    def insert_after(target, middleware, *args, **kwargs)
+      @operations << [:after, target, middleware, args, kwargs]
+    end
+
+    def insert_before(target, middleware, *args, **kwargs)
+      @operations << [:before, target, middleware, args, kwargs]
+    end
+
+    def use(middleware, *args, **kwargs)
+      @operations << [:use, nil, middleware, args, kwargs]
+    end
+  end
+
+  class FakeApp
+    attr_reader :config, :middleware
+
+    def initialize
+      @config = Struct.new(:verikloak).new(ActiveSupport::OrderedOptions.new)
+      @middleware = FakeMiddlewareStack.new
+    end
+  end
+
+  let(:app) { FakeApp.new }
+
+  def run_initializer
+    configure_initializer.run(app)
+  end
+
+  it 'inserts base middleware after Rails::Rack::Logger by default' do
+    stub_const('Verikloak::Bff::HeaderGuard', Class.new)
+    run_initializer
+    operation = app.middleware.operations.find { |kind, _, middleware, _, _| kind == :after && middleware == Verikloak::Middleware }
+    expect(operation).not_to be_nil
+    expect(operation[1]).to eq(::Rails::Rack::Logger)
+  end
+
+  it 'supports configuring insert_before' do
+    app.config.verikloak.middleware_insert_before = :some_middleware
+    stub_const('Verikloak::Bff::HeaderGuard', Class.new)
+    run_initializer
+    operation = app.middleware.operations.find { |kind, target, middleware, _, _| kind == :before && middleware == Verikloak::Middleware }
+    expect(operation).not_to be_nil
+    expect(operation[1]).to eq(:some_middleware)
+  end
+
+  it 'supports configuring insert_after' do
+    app.config.verikloak.middleware_insert_after = :another
+    stub_const('Verikloak::Bff::HeaderGuard', Class.new)
+    run_initializer
+    operation = app.middleware.operations.find { |kind, target, middleware, _, _| kind == :after && middleware == Verikloak::Middleware }
+    expect(operation).not_to be_nil
+    expect(operation[1]).to eq(:another)
+  end
+
+  it 'auto inserts the BFF header guard before the base middleware when present' do
+    guard = Class.new
+    stub_const('Verikloak::Bff::HeaderGuard', guard)
+    run_initializer
+    expect(app.middleware.operations).to include([:before, Verikloak::Middleware, guard, [], {}])
+  end
+
+  it 'skips inserting the BFF header guard when disabled' do
+    app.config.verikloak.auto_insert_bff_header_guard = false
+    guard = Class.new
+    stub_const('Verikloak::Bff::HeaderGuard', guard)
+    run_initializer
+    expect(app.middleware.operations.none? { |_, _, middleware, _, _| middleware == guard }).to be(true)
+  end
+
+  it 'disables Pundit rescue when verikloak-pundit is present and config is not set' do
+    stub_const('Verikloak::Pundit', Module.new)
+    run_initializer
+    expect(Verikloak::Rails.config.rescue_pundit).to eq(false)
+  end
+
+  it 'respects explicit rescue_pundit configuration even when verikloak-pundit is present' do
+    app.config.verikloak.rescue_pundit = true
+    stub_const('Verikloak::Pundit', Module.new)
+    run_initializer
+    expect(Verikloak::Rails.config.rescue_pundit).to eq(true)
+  end
+end

--- a/spec/railtie_spec.rb
+++ b/spec/railtie_spec.rb
@@ -88,6 +88,22 @@ RSpec.describe Verikloak::Rails::Railtie do
     expect(app.middleware.operations).to include([:before, Verikloak::Middleware, guard, [], {}])
   end
 
+  it 'inserts the BFF header guard before a configured middleware when requested' do
+    app.config.verikloak.bff_header_guard_insert_before = :another_guard
+    guard = Class.new
+    stub_const('Verikloak::Bff::HeaderGuard', guard)
+    run_initializer
+    expect(app.middleware.operations).to include([:before, :another_guard, guard, [], {}])
+  end
+
+  it 'inserts the BFF header guard after a configured middleware when requested' do
+    app.config.verikloak.bff_header_guard_insert_after = :after_target
+    guard = Class.new
+    stub_const('Verikloak::Bff::HeaderGuard', guard)
+    run_initializer
+    expect(app.middleware.operations).to include([:after, :after_target, guard, [], {}])
+  end
+
   it 'skips inserting the BFF header guard when disabled' do
     app.config.verikloak.auto_insert_bff_header_guard = false
     guard = Class.new

--- a/spec/verikloak/rails/controller_spec.rb
+++ b/spec/verikloak/rails/controller_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'verikloak/rails'
+require 'verikloak/rails/controller'
+
+RSpec.describe Verikloak::Rails::Controller do
+  let(:controller_class) do
+    Class.new do
+      class << self
+        def before_action(*) = nil
+        def rescue_from(*) = nil
+        def around_action(*) = nil
+      end
+
+      include Verikloak::Rails::Controller
+
+      attr_reader :request, :render_calls
+
+      def initialize(request)
+        @request = request
+        @render_calls = []
+      end
+
+      def render(**options)
+        @render_calls << options
+      end
+    end
+  end
+
+  let(:controller) { controller_class.new(request) }
+  let(:env) { { 'verikloak.token' => nil } }
+  let(:request) do
+    instance_double('ActionDispatch::Request', env: env, headers: {}, request_id: nil)
+  end
+
+  before do
+    Verikloak::Rails.instance_variable_set(:@config, nil)
+  end
+
+  describe '#current_token' do
+    it 'falls back to RequestStore when the Rack env token is missing' do
+      store_class = Class.new do
+        class << self
+          def store
+            @store ||= {}
+          end
+        end
+      end
+
+      stub_const('RequestStore', store_class)
+      RequestStore.store[:verikloak_token] = 'stored-token'
+
+      expect(controller.current_token).to eq('stored-token')
+    end
+  end
+
+  describe '#_verikloak_base_logger' do
+    it 'walks nested loggers to locate the innermost logger with error support' do
+      inner_logger = Class.new do
+        def error(*) = nil
+      end.new
+
+      middle_logger = Struct.new(:logger).new(inner_logger)
+      root_logger = Struct.new(:logger).new(middle_logger)
+
+      allow(::Rails).to receive(:logger).and_return(root_logger)
+
+      expect(controller.send(:_verikloak_base_logger)).to equal(inner_logger)
+    end
+  end
+
+  describe '#_verikloak_log_internal_error' do
+    it 'swallows logging failures from the chosen logger' do
+      failing_logger = Class.new do
+        def error(*)
+          raise StandardError, 'logging failed'
+        end
+      end.new
+
+      allow(controller).to receive(:_verikloak_base_logger).and_return(failing_logger)
+
+      exception = RuntimeError.new('boom')
+      exception.set_backtrace(['line:42'])
+
+      expect { controller.send(:_verikloak_log_internal_error, exception) }.not_to raise_error
+    end
+  end
+end

--- a/verikloak-rails.gemspec
+++ b/verikloak-rails.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   # Runtime dependencies
   spec.add_dependency 'rails', '>= 6.1', '< 9.0'
-  spec.add_dependency 'verikloak', '>= 0.1.2', '< 0.2'
+  spec.add_dependency 'verikloak', '>= 0.1.5', '< 1.0.0'
 
   # Metadata for RubyGems
   spec.metadata['source_code_uri'] = spec.homepage


### PR DESCRIPTION
## Summary
- allow configuring where the core Verikloak middleware is inserted and auto-detect verikloak-pundit
- auto-insert Verikloak::Bff::HeaderGuard when the gem is present, with toggles for ordering
- update docs, installer messaging, and add unit/integration specs for the new behavior