### PR TITLE
Prepare v0.2.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.2.4] - 2025-09-23
+
+### Fixed
+- Package the installer template so `rails g verikloak:install` works in packaged gems (no more missing `initializer.rb.erb`).
+
+---
+
 ## [0.2.3] - 2025-09-22
 
 ### Changed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    verikloak-rails (0.2.3)
+    verikloak-rails (0.2.4)
       rack (>= 2.2, < 4.0)
       rails (>= 6.1, < 9.0)
       verikloak (>= 0.2.0, < 1.0.0)

--- a/docker/dev.Dockerfile
+++ b/docker/dev.Dockerfile
@@ -4,8 +4,7 @@ FROM ruby:3.4.5-alpine3.22
 # Base packages:
 # - Runtime: bash (for CI commands), git (bundler-audit update), openssl (runtime lib), tzdata, libstdc++
 # - Build deps: build-base, openssl-dev (for native extensions) — removed after bundle install
-RUN apk upgrade --no-cache && \
-    apk add --no-cache \
+RUN apk add --no-cache \
       bash \
       git \
       openssl \

--- a/lib/verikloak/rails/version.rb
+++ b/lib/verikloak/rails/version.rb
@@ -2,6 +2,6 @@
 
 module Verikloak
   module Rails
-    VERSION = '0.2.3'
+    VERSION = '0.2.4'
   end
 end

--- a/verikloak-rails.gemspec
+++ b/verikloak-rails.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage    = 'https://github.com/taiyaky/verikloak-rails'
   spec.license     = 'MIT'
 
-  spec.files         = Dir['lib/**/*.rb'] + %w[README.md LICENSE CHANGELOG.md]
+  spec.files         = Dir['lib/**/*.{rb,erb}'] + %w[README.md LICENSE CHANGELOG.md]
   spec.require_paths = ['lib']
 
   spec.required_ruby_version = '>= 3.1'


### PR DESCRIPTION
## Summary
- package the installer template (`initializer.rb.erb`) so `rails g verikloak:install` works when using the published gem
- document the fix in the changelog and bump the gem version to 0.2.4 for release
- simplify the dev Docker image setup by skipping `apk upgrade` while keeping required packages installed
