### PR TITLE
Clarify verikloak-pundit auto-disable behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [Unreleased]
+## [0.2.6] - 2025-09-23
 
 ### Fixed
 - Leave `config.verikloak.rescue_pundit` commented in the installer initializer so `verikloak-pundit` can automatically disable the built-in rescue.
@@ -15,8 +15,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Documentation
 - Align README compatibility with the current `verikloak` dependency range.
 - Clarify how the Pundit rescue interacts with the optional `verikloak-pundit` gem and adjust examples accordingly.
-
----
 
 ## [0.2.5] - 2025-09-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- Leave `config.verikloak.rescue_pundit` commented in the installer initializer so `verikloak-pundit` can automatically disable the built-in rescue.
+
+### Documentation
+- Align README compatibility with the current `verikloak` dependency range.
+- Clarify how the Pundit rescue interacts with the optional `verikloak-pundit` gem and adjust examples accordingly.
+
+---
+
 ## [0.2.5] - 2025-09-23
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    verikloak-rails (0.2.5)
+    verikloak-rails (0.2.6)
       rack (>= 2.2, < 4.0)
       rails (>= 6.1, < 9.0)
       verikloak (>= 0.2.0, < 1.0.0)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Provide drop-in, token-based authentication for Rails APIs via Verikloak (OIDC d
 ## Compatibility
 - Ruby: >= 3.1
 - Rails: 6.1 – 8.x
-- verikloak: >= 0.1.2, < 0.2
+- verikloak: >= 0.2.0, < 1.0.0
 
 ## Quick Start
 ```bash
@@ -114,7 +114,7 @@ Keys under `config.verikloak`:
 | `error_renderer` | Object responding to `render(controller, error)` | Override error rendering | built-in JSON renderer |
 | `auto_include_controller` | Boolean | Auto-include controller concern | `true` |
 | `render_500_json` | Boolean | Rescue `StandardError`, log the exception, and render JSON 500 | `false` |
-| `rescue_pundit` | Boolean | Rescue `Pundit::NotAuthorizedError` to 403 JSON when Pundit is present (auto-disabled when `verikloak-pundit` is loaded) | `true` |
+| `rescue_pundit` | Boolean | Rescue `Pundit::NotAuthorizedError` to 403 JSON when Pundit is present (auto-disabled when `verikloak-pundit` is loaded and the initializer leaves it unset) | `true` |
 | `middleware_insert_before` | Object/String/Symbol | Insert `Verikloak::Middleware` before this Rack middleware | `nil` |
 | `middleware_insert_after` | Object/String/Symbol | Insert `Verikloak::Middleware` after this Rack middleware (`Rails::Rack::Logger` when `nil`) | `nil` |
 | `auto_insert_bff_header_guard` | Boolean | Auto insert `Verikloak::Bff::HeaderGuard` when the gem is present | `true` |
@@ -157,8 +157,9 @@ Rails.application.configure do
   config.verikloak.logger_tags = %i[request_id sub]
   config.verikloak.render_500_json = ENV.fetch('VERIKLOAK_RENDER_500', 'false') == 'true'
 
-  # Optional Pundit rescue (403 JSON)
-  config.verikloak.rescue_pundit = ENV.fetch('VERIKLOAK_RESCUE_PUNDIT', 'true') == 'true'
+  # Optional Pundit rescue (403 JSON). Leave commented if you use
+  # verikloak-pundit so it can disable the built-in handler automatically.
+  # config.verikloak.rescue_pundit = ENV.fetch('VERIKLOAK_RESCUE_PUNDIT', 'true') == 'true'
 end
 ```
 
@@ -232,10 +233,10 @@ end
 ## Optional Pundit Rescue
 If the `pundit` gem is present, `Pundit::NotAuthorizedError` is rescued to a standardized 403 JSON. This is a lightweight convenience only; deeper Pundit integration (policies, helpers) is out of scope and can live in a separate plugin.
 
-When the optional [`verikloak-pundit`](https://github.com/taiyaky/verikloak-pundit) gem is loaded, the built-in rescue is automatically disabled to avoid double-handling errors. Explicitly set `config.verikloak.rescue_pundit` if you prefer different behavior.
+When the optional [`verikloak-pundit`](https://github.com/taiyaky/verikloak-pundit) gem is loaded, the built-in rescue is automatically disabled to avoid double-handling errors—as long as the initializer leaves `config.verikloak.rescue_pundit` unset. Uncomment the initializer line (or set the value elsewhere) if you prefer different behavior.
 
 ### Toggle
-Toggle with `config.verikloak.rescue_pundit` (default: true unless overridden by `verikloak-pundit`). Environment example:
+Toggle with `config.verikloak.rescue_pundit` (default: true; leave unset to allow `verikloak-pundit` to disable it). Environment example:
 
 ```ruby
 # config/initializers/verikloak.rb

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Keys under `config.verikloak`:
 | `error_renderer` | Object responding to `render(controller, error)` | Override error rendering | built-in JSON renderer |
 | `auto_include_controller` | Boolean | Auto-include controller concern | `true` |
 | `render_500_json` | Boolean | Rescue `StandardError`, log the exception, and render JSON 500 | `false` |
-| `rescue_pundit` | Boolean | Rescue `Pundit::NotAuthorizedError` to 403 JSON when Pundit is present (auto-disabled when `verikloak-pundit` is loaded and the initializer leaves it unset) | `true` |
+| `rescue_pundit` | Boolean | Rescue `Pundit::NotAuthorizedError` to 403 JSON when Pundit is present<br/>(auto-disabled when `verikloak-pundit` is loaded and the initializer leaves it unset) | `true` |
 | `middleware_insert_before` | Object/String/Symbol | Insert `Verikloak::Middleware` before this Rack middleware | `nil` |
 | `middleware_insert_after` | Object/String/Symbol | Insert `Verikloak::Middleware` after this Rack middleware (`Rails::Rack::Logger` when `nil`) | `nil` |
 | `auto_insert_bff_header_guard` | Boolean | Auto insert `Verikloak::Bff::HeaderGuard` when the gem is present | `true` |

--- a/lib/generators/verikloak/install/install_generator.rb
+++ b/lib/generators/verikloak/install/install_generator.rb
@@ -26,7 +26,7 @@ module Verikloak
           ✅ verikloak: initializer created.
 
           Next steps:
-          1) Ensure the base gem is installed:   gem 'verikloak', '>= 0.1.2', '< 0.2'
+          1) Ensure the base gem is installed:   gem 'verikloak', '>= 0.2.0', '< 1.0.0'
           2) Set discovery_url / audience in config/initializers/verikloak.rb
           3) (Optional) If you disable auto-include, add this line to ApplicationController:
                include Verikloak::Rails::Controller

--- a/lib/generators/verikloak/install/templates/initializer.rb.erb
+++ b/lib/generators/verikloak/install/templates/initializer.rb.erb
@@ -10,5 +10,8 @@ Rails.application.configure do
   config.verikloak.logger_tags = %i[request_id sub]
   config.verikloak.auto_include_controller = true
   config.verikloak.render_500_json = ENV.fetch('VERIKLOAK_RENDER_500', 'false') == 'true'
-  config.verikloak.rescue_pundit = ENV.fetch('VERIKLOAK_RESCUE_PUNDIT', 'true') == 'true'
+
+  # Optional Pundit rescue (403 JSON). Leave commented so `verikloak-pundit`
+  # can auto-disable the built-in handler when it is on the load path.
+  # config.verikloak.rescue_pundit = ENV.fetch('VERIKLOAK_RESCUE_PUNDIT', 'true') == 'true'
 end

--- a/lib/verikloak/rails/version.rb
+++ b/lib/verikloak/rails/version.rb
@@ -2,6 +2,6 @@
 
 module Verikloak
   module Rails
-    VERSION = '0.2.5'
+    VERSION = '0.2.6'
   end
 end

--- a/spec/integration/pundit_integration_spec.rb
+++ b/spec/integration/pundit_integration_spec.rb
@@ -4,6 +4,12 @@ require 'spec_helper'
 require 'verikloak/rails'
 
 RSpec.describe 'Pundit integration auto-disable behavior' do
+  # Configuration keys to copy from Rails configuration
+  CONFIG_KEYS = %i[discovery_url audience issuer leeway skip_paths
+                   logger_tags error_renderer auto_include_controller
+                   render_500_json rescue_pundit middleware_insert_before
+                   middleware_insert_after auto_insert_bff_header_guard
+                   bff_header_guard_insert_before bff_header_guard_insert_after].freeze
   before do
     Verikloak::Rails.reset!
   end
@@ -23,11 +29,7 @@ RSpec.describe 'Pundit integration auto-disable behavior' do
       # Note: rescue_pundit key is intentionally not set
 
       Verikloak::Rails.configure do |c|
-        %i[discovery_url audience issuer leeway skip_paths
-           logger_tags error_renderer auto_include_controller
-           render_500_json rescue_pundit middleware_insert_before
-           middleware_insert_after auto_insert_bff_header_guard
-           bff_header_guard_insert_before bff_header_guard_insert_after].each do |key|
+        CONFIG_KEYS.each do |key|
           c.send("#{key}=", rails_cfg[key]) if rails_cfg.key?(key)
         end
         # This is the key logic from the Railtie
@@ -46,11 +48,7 @@ RSpec.describe 'Pundit integration auto-disable behavior' do
       rails_cfg.rescue_pundit = true  # Explicitly set
 
       Verikloak::Rails.configure do |c|
-        %i[discovery_url audience issuer leeway skip_paths
-           logger_tags error_renderer auto_include_controller
-           render_500_json rescue_pundit middleware_insert_before
-           middleware_insert_after auto_insert_bff_header_guard
-           bff_header_guard_insert_before bff_header_guard_insert_after].each do |key|
+        CONFIG_KEYS.each do |key|
           c.send("#{key}=", rails_cfg[key]) if rails_cfg.key?(key)
         end
         # Should NOT auto-disable because rescue_pundit was explicitly set
@@ -79,11 +77,7 @@ RSpec.describe 'Pundit integration auto-disable behavior' do
       rails_cfg.audience = 'test-audience'
 
       Verikloak::Rails.configure do |c|
-        %i[discovery_url audience issuer leeway skip_paths
-           logger_tags error_renderer auto_include_controller
-           render_500_json rescue_pundit middleware_insert_before
-           middleware_insert_after auto_insert_bff_header_guard
-           bff_header_guard_insert_before bff_header_guard_insert_after].each do |key|
+        CONFIG_KEYS.each do |key|
           c.send("#{key}=", rails_cfg[key]) if rails_cfg.key?(key)
         end
         # Should NOT auto-disable because verikloak-pundit is not present

--- a/spec/integration/pundit_integration_spec.rb
+++ b/spec/integration/pundit_integration_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'verikloak/rails'
+
+RSpec.describe 'Pundit integration auto-disable behavior' do
+  before do
+    Verikloak::Rails.reset!
+  end
+
+  context 'when verikloak-pundit is loaded' do
+    before do
+      # Mock the verikloak-pundit gem being loaded
+      stub_const('::Verikloak::Pundit', Module.new)
+    end
+
+    it 'auto-disables rescue_pundit when not explicitly configured' do
+      # Simulate Rails configuration without rescue_pundit key
+      require 'active_support/ordered_options'
+      rails_cfg = ActiveSupport::OrderedOptions.new
+      rails_cfg.discovery_url = 'https://example/.well-known/openid-configuration'
+      rails_cfg.audience = 'test-audience'
+      # Note: rescue_pundit key is intentionally not set
+
+      Verikloak::Rails.configure do |c|
+        %i[discovery_url audience issuer leeway skip_paths
+           logger_tags error_renderer auto_include_controller
+           render_500_json rescue_pundit middleware_insert_before
+           middleware_insert_after auto_insert_bff_header_guard
+           bff_header_guard_insert_before bff_header_guard_insert_after].each do |key|
+          c.send("#{key}=", rails_cfg[key]) if rails_cfg.key?(key)
+        end
+        # This is the key logic from the Railtie
+        c.rescue_pundit = false if !rails_cfg.key?(:rescue_pundit) && defined?(::Verikloak::Pundit)
+      end
+
+      expect(Verikloak::Rails.config.rescue_pundit).to eq(false)
+    end
+
+    it 'respects explicit rescue_pundit configuration' do
+      # Simulate Rails configuration with explicit rescue_pundit setting
+      require 'active_support/ordered_options'
+      rails_cfg = ActiveSupport::OrderedOptions.new
+      rails_cfg.discovery_url = 'https://example/.well-known/openid-configuration'
+      rails_cfg.audience = 'test-audience'
+      rails_cfg.rescue_pundit = true  # Explicitly set
+
+      Verikloak::Rails.configure do |c|
+        %i[discovery_url audience issuer leeway skip_paths
+           logger_tags error_renderer auto_include_controller
+           render_500_json rescue_pundit middleware_insert_before
+           middleware_insert_after auto_insert_bff_header_guard
+           bff_header_guard_insert_before bff_header_guard_insert_after].each do |key|
+          c.send("#{key}=", rails_cfg[key]) if rails_cfg.key?(key)
+        end
+        # Should NOT auto-disable because rescue_pundit was explicitly set
+        c.rescue_pundit = false if !rails_cfg.key?(:rescue_pundit) && defined?(::Verikloak::Pundit)
+      end
+
+      expect(Verikloak::Rails.config.rescue_pundit).to eq(true)
+    end
+  end
+
+  context 'when verikloak-pundit is not loaded' do
+    it 'defaults rescue_pundit to true' do
+      Verikloak::Rails.configure do |config|
+        config.discovery_url = 'https://example/.well-known/openid-configuration'
+        config.audience = 'test-audience'
+      end
+
+      expect(Verikloak::Rails.config.rescue_pundit).to eq(true)
+    end
+
+    it 'keeps rescue_pundit true when not explicitly configured' do
+      # Simulate Rails configuration without rescue_pundit key
+      require 'active_support/ordered_options'
+      rails_cfg = ActiveSupport::OrderedOptions.new
+      rails_cfg.discovery_url = 'https://example/.well-known/openid-configuration'
+      rails_cfg.audience = 'test-audience'
+
+      Verikloak::Rails.configure do |c|
+        %i[discovery_url audience issuer leeway skip_paths
+           logger_tags error_renderer auto_include_controller
+           render_500_json rescue_pundit middleware_insert_before
+           middleware_insert_after auto_insert_bff_header_guard
+           bff_header_guard_insert_before bff_header_guard_insert_after].each do |key|
+          c.send("#{key}=", rails_cfg[key]) if rails_cfg.key?(key)
+        end
+        # Should NOT auto-disable because verikloak-pundit is not present
+        c.rescue_pundit = false if !rails_cfg.key?(:rescue_pundit) && defined?(::Verikloak::Pundit)
+      end
+
+      expect(Verikloak::Rails.config.rescue_pundit).to eq(true)
+    end
+  end
+end

--- a/spec/integration/rails_integration_spec.rb
+++ b/spec/integration/rails_integration_spec.rb
@@ -112,9 +112,8 @@ class TestApp < Rails::Application
   config.consider_all_requests_local = true
   # Opt in to Rails 8.1 behavior to avoid deprecation around `to_time`
   config.active_support.to_time_preserves_timezone = :zone
-  if config.respond_to?(:hosts) && config.hosts.respond_to?(:clear)
-    config.hosts.clear
-  end
+  # Clear allowed hosts for testing
+  config.hosts.clear if config.respond_to?(:hosts)
   config.logger = Logger.new(nil)
 
   # verikloak-rails configuration

--- a/spec/stubs/verikloak/middleware.rb
+++ b/spec/stubs/verikloak/middleware.rb
@@ -4,7 +4,13 @@
 # It simulates successful authentication when a bearer token 'valid' is present.
 
 module Verikloak
+  # Stub missing error classes that the real middleware expects
+  class DiscoveryError < StandardError; end
+
   class Middleware
+    # Stub missing error classes
+    class MiddlewareError < StandardError; end
+
     class << self
       attr_accessor :last_options
     end


### PR DESCRIPTION
## Summary
- stop the installer from eagerly setting `config.verikloak.rescue_pundit` so verikloak-pundit can disable the built-in rescue automatically
- document the dependency range update and explain how the Pundit rescue behaves when verikloak-pundit is present
- add unreleased changelog notes covering the above fixes and documentation tweaks