### PR TITLE
Improve middleware insertion compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.2.7] - 2025-09-23
+
+### Fixed
+- Handle `RuntimeError` exceptions from `ActionDispatch::MiddlewareStack#insert_after` in Rails 8+
+- Add `inserted` flag to prevent duplicate middleware insertion when fallback is used
+- Enhance error handling to gracefully handle all middleware insertion failures
+
+### Changed
+- Update middleware insertion candidates logic for better Rails version compatibility
+  - Rails 8+ now raises `RuntimeError` instead of the deprecated `ActionDispatch::MiddlewareStack::MiddlewareNotFound`
+  - Broaden exception handling to catch `StandardError` for robustness across Rails versions
+  - Improve logging and debugging information for middleware insertion failures
+
 ## [0.2.6] - 2025-09-23
 
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    verikloak-rails (0.2.6)
+    verikloak-rails (0.2.7)
       rack (>= 2.2, < 4.0)
       rails (>= 6.1, < 9.0)
       verikloak (>= 0.2.0, < 1.0.0)

--- a/lib/verikloak/rails/railtie.rb
+++ b/lib/verikloak/rails/railtie.rb
@@ -137,6 +137,7 @@ module Verikloak
         # @return [void]
         def insert_middleware_after(stack, base_options)
           candidates = middleware_insert_after_candidates
+          inserted = false
 
           candidates.each do |candidate|
             next unless candidate
@@ -145,13 +146,18 @@ module Verikloak
               stack.insert_after candidate,
                                  ::Verikloak::Middleware,
                                  **base_options
+              inserted = true
               break
-            rescue ::ActionDispatch::MiddlewareStack::MiddlewareNotFound => e
+            rescue StandardError => e
+              # Handle middleware insertion failures:
+              # - Rails 8+: RuntimeError for missing middleware
+              # - Earlier versions: ActionDispatch::MiddlewareStack::MiddlewareNotFound
               log_middleware_insertion_warning(candidate, e)
             end
           end
 
-          stack.use ::Verikloak::Middleware, **base_options
+          # Only use as fallback if insertion after a specific middleware failed
+          stack.use ::Verikloak::Middleware, **base_options unless inserted
         end
 
         # Build list of middleware to try as insertion points.
@@ -174,7 +180,7 @@ module Verikloak
         # Log when a middleware insertion target cannot be found.
         #
         # @param candidate [Object] middleware we attempted to insert after
-        # @param error [ActionDispatch::MiddlewareStack::MiddlewareNotFound]
+        # @param error [StandardError] the exception raised during insertion
         # @return [void]
         def log_middleware_insertion_warning(candidate, error)
           candidate_name = candidate.is_a?(Class) ? candidate.name : candidate.class.name

--- a/lib/verikloak/rails/railtie.rb
+++ b/lib/verikloak/rails/railtie.rb
@@ -177,7 +177,8 @@ module Verikloak
         # @param error [ActionDispatch::MiddlewareStack::MiddlewareNotFound]
         # @return [void]
         def log_middleware_insertion_warning(candidate, error)
-          message = "[verikloak] Unable to insert after #{candidate.inspect}: #{error.message}"
+          candidate_name = candidate.is_a?(Class) ? candidate.name : candidate.class.name
+          message = "[verikloak] Unable to insert after #{candidate_name}: #{error.message}"
           if defined?(::Rails) && ::Rails.respond_to?(:logger) && ::Rails.logger
             ::Rails.logger.warn(message)
           else

--- a/lib/verikloak/rails/railtie.rb
+++ b/lib/verikloak/rails/railtie.rb
@@ -145,7 +145,7 @@ module Verikloak
               stack.insert_after candidate,
                                  ::Verikloak::Middleware,
                                  **base_options
-              return
+              break
             rescue ::ActionDispatch::MiddlewareStack::MiddlewareNotFound => e
               log_middleware_insertion_warning(candidate, e)
             end

--- a/lib/verikloak/rails/version.rb
+++ b/lib/verikloak/rails/version.rb
@@ -2,6 +2,6 @@
 
 module Verikloak
   module Rails
-    VERSION = '0.2.6'
+    VERSION = '0.2.7'
   end
 end

--- a/spec/verikloak/rails/railtie_spec.rb
+++ b/spec/verikloak/rails/railtie_spec.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Load Rails and ActionDispatch for the test
+require 'rails'
+require 'action_controller/railtie'
+
+require 'verikloak/rails'
+
+RSpec.describe Verikloak::Rails::Railtie, type: :railtie do
+  describe '.middleware_insert_after_candidates' do
+    let(:railtie) { described_class }
+    
+    before do
+      Verikloak::Rails.reset!
+    end
+
+    context 'with default configuration' do
+      it 'returns fallback middleware candidates when configured value is nil' do
+        Verikloak::Rails.configure do |config|
+          config.middleware_insert_after = nil
+        end
+
+        candidates = railtie.send(:middleware_insert_after_candidates)
+        
+        # Should contain only the defaults (no configured value)
+        expect(candidates).to include(::Rails::Rack::Logger) if defined?(::Rails::Rack::Logger)
+        expect(candidates).to include(::ActionDispatch::Executor) if defined?(::ActionDispatch::Executor)
+        expect(candidates).to include(::Rack::Head) if defined?(::Rack::Head)
+        expect(candidates).to include(::Rack::Runtime) if defined?(::Rack::Runtime)
+      end
+    end
+
+    context 'with configured middleware_insert_after' do
+      it 'prioritizes configured value and includes fallbacks' do
+        Verikloak::Rails.configure do |config|
+          config.middleware_insert_after = ::ActionDispatch::Static
+        end
+
+        candidates = railtie.send(:middleware_insert_after_candidates)
+        
+        # Should start with configured value
+        expect(candidates.first).to eq(::ActionDispatch::Static)
+        
+        # Should also include fallbacks
+        expect(candidates).to include(::Rails::Rack::Logger) if defined?(::Rails::Rack::Logger)
+        expect(candidates).to include(::ActionDispatch::Executor) if defined?(::ActionDispatch::Executor)
+      end
+    end
+
+    context 'with Rails 8 compatibility' do
+      it 'handles Rails 8 middleware stack gracefully' do
+        # Ensure we're testing with the actual middleware classes
+        expect(defined?(::Rails::Rack::Logger)).to eq('constant')
+        expect(defined?(::ActionDispatch::Executor)).to eq('constant')
+        expect(defined?(::Rack::Head)).to eq('constant')
+        expect(defined?(::Rack::Runtime)).to eq('constant')
+
+        Verikloak::Rails.configure do |config|
+          config.middleware_insert_after = nil
+        end
+
+        candidates = railtie.send(:middleware_insert_after_candidates)
+        
+        # All expected middleware should be present in Rails 8
+        expect(candidates).to include(::Rails::Rack::Logger)
+        expect(candidates).to include(::ActionDispatch::Executor)
+        expect(candidates).to include(::Rack::Head)
+        expect(candidates).to include(::Rack::Runtime)
+        
+        # Should be unique (no duplicates)
+        expect(candidates.uniq).to eq(candidates)
+      end
+    end
+  end
+
+  describe '.insert_middleware_after' do
+    let(:railtie) { described_class }
+    let(:middleware_stack) { double('MiddlewareStack') }
+    let(:base_options) { { discovery_url: 'https://test.example.com' } }
+
+    before do
+      Verikloak::Rails.reset!
+      allow(railtie).to receive(:log_middleware_insertion_warning)
+    end
+
+    context 'when first candidate succeeds' do
+      it 'inserts middleware and breaks from loop' do
+        Verikloak::Rails.configure do |config|
+          config.middleware_insert_after = ::ActionDispatch::Static
+        end
+
+        expect(middleware_stack).to receive(:insert_after)
+          .with(::ActionDispatch::Static, ::Verikloak::Middleware, **base_options)
+          .and_return(true)
+        expect(middleware_stack).not_to receive(:use)
+
+        railtie.send(:insert_middleware_after, middleware_stack, base_options)
+      end
+    end
+
+    context 'when first candidate fails but second succeeds' do
+      it 'tries next candidate and succeeds' do
+        # Create a mock class for non-existent middleware
+        non_existent_middleware = Class.new
+        stub_const('NonExistentMiddleware', non_existent_middleware)
+        
+        Verikloak::Rails.configure do |config|
+          config.middleware_insert_after = non_existent_middleware
+        end
+
+        # First attempt fails
+        expect(middleware_stack).to receive(:insert_after)
+          .with(non_existent_middleware, ::Verikloak::Middleware, **base_options)
+          .and_raise(StandardError.new('MiddlewareNotFound: not found'))
+
+        # Second attempt succeeds (with Rails::Rack::Logger as fallback)
+        expect(middleware_stack).to receive(:insert_after)
+          .with(::Rails::Rack::Logger, ::Verikloak::Middleware, **base_options)
+          .and_return(true)
+
+        expect(middleware_stack).not_to receive(:use)
+        expect(railtie).to receive(:log_middleware_insertion_warning)
+
+        railtie.send(:insert_middleware_after, middleware_stack, base_options)
+      end
+    end
+
+    context 'when all candidates fail' do
+      it 'falls back to using middleware at the end' do
+        # Create mock classes for non-existent middleware
+        non_existent_middleware1 = Class.new
+        non_existent_middleware2 = Class.new
+        stub_const('NonExistentMiddleware1', non_existent_middleware1)
+        stub_const('NonExistentMiddleware2', non_existent_middleware2)
+        
+        # Mock all candidates to fail
+        allow(railtie).to receive(:middleware_insert_after_candidates)
+          .and_return([non_existent_middleware1, non_existent_middleware2])
+
+        expect(middleware_stack).to receive(:insert_after).twice
+          .and_raise(StandardError.new('MiddlewareNotFound: not found'))
+
+        expect(middleware_stack).to receive(:use)
+          .with(::Verikloak::Middleware, **base_options)
+
+        expect(railtie).to receive(:log_middleware_insertion_warning).twice
+
+        railtie.send(:insert_middleware_after, middleware_stack, base_options)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add fallback middleware insertion targets compatible with Rails 8 when Rails::Rack::Logger is unavailable
- gracefully log and fall back to appending when configured insertion points are missing