### PR TITLE
Inline BFF guard insertion into middleware configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.2.8] - 2025-01-03
+
+### Changed
+- Refactor controller helpers to use shared `_verikloak_fetch_request_context` method for consistent RequestStore fallback handling
+- Optimize configuration access by caching `Verikloak::Rails.config` in log tag building
+- Extract `auth_headers` method in ErrorRenderer for reusable WWW-Authenticate header generation
+- Streamline middleware configuration by inlining BFF guard insertion into main configuration flow
+- Improve middleware insertion error handling with `try_insert_after` and `warn_with_fallback` utilities
+
+### Added
+- Support for advanced middleware options: `token_verify_options`, `decoder_cache_limit`, `token_env_key`, `user_env_key`
+- `bff_header_guard_options` configuration for verikloak-bff library integration
+- Centralized `CONFIG_KEYS` constant in Railtie for consistent configuration management
+- Enhanced README documentation with RequestStore vs Rack environment priority examples
+
+### Fixed
+- Only call `configure_bff_guard` when middleware stack is successfully created
+- Replace `each_with_object` with `transform_keys` for better Ruby style compliance
+
 ## [0.2.7] - 2025-09-23
 
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    verikloak-rails (0.2.7)
+    verikloak-rails (0.2.8)
       rack (>= 2.2, < 4.0)
       rails (>= 6.1, < 9.0)
       verikloak (>= 0.2.0, < 1.0.0)

--- a/lib/verikloak/rails/configuration.rb
+++ b/lib/verikloak/rails/configuration.rb
@@ -59,7 +59,9 @@ module Verikloak
                     :render_500_json, :rescue_pundit,
                     :middleware_insert_before, :middleware_insert_after,
                     :auto_insert_bff_header_guard,
-                    :bff_header_guard_insert_before, :bff_header_guard_insert_after
+                    :bff_header_guard_insert_before, :bff_header_guard_insert_after,
+                    :token_verify_options, :decoder_cache_limit,
+                    :token_env_key, :user_env_key, :bff_header_guard_options
 
       # Initialize configuration with sensible defaults for Rails apps.
       # @return [void]
@@ -79,6 +81,11 @@ module Verikloak
         @auto_insert_bff_header_guard = true
         @bff_header_guard_insert_before = nil
         @bff_header_guard_insert_after = nil
+        @token_verify_options = {}
+        @decoder_cache_limit = nil
+        @token_env_key = nil
+        @user_env_key = nil
+        @bff_header_guard_options = {}
       end
 
       # Options forwarded to the base Verikloak Rack middleware.
@@ -92,7 +99,11 @@ module Verikloak
           audience: audience,
           issuer: issuer,
           leeway: leeway,
-          skip_paths: skip_paths
+          skip_paths: skip_paths,
+          token_verify_options: token_verify_options,
+          decoder_cache_limit: decoder_cache_limit,
+          token_env_key: token_env_key,
+          user_env_key: user_env_key
         }.compact
       end
     end

--- a/lib/verikloak/rails/railtie.rb
+++ b/lib/verikloak/rails/railtie.rb
@@ -16,8 +16,7 @@ module Verikloak
       # Apply configuration and insert middleware.
       # @return [void]
       initializer 'verikloak.configure' do |app|
-        stack = ::Verikloak::Rails::Railtie.send(:configure_middleware, app)
-        ::Verikloak::Rails::Railtie.send(:configure_bff_guard, stack) if stack
+        ::Verikloak::Rails::Railtie.send(:configure_middleware, app)
       end
 
       # Optionally include the controller concern when ActionController loads.
@@ -43,7 +42,10 @@ module Verikloak
             return
           end
 
-          insert_base_middleware(app)
+          stack = insert_base_middleware(app)
+          configure_bff_guard(stack)
+
+          stack
         end
 
         # Insert the optional HeaderGuard middleware when verikloak-bff is present.

--- a/lib/verikloak/rails/railtie.rb
+++ b/lib/verikloak/rails/railtie.rb
@@ -11,6 +11,16 @@ module Verikloak
     # - Inserts base `Verikloak::Middleware`
     # - Auto-includes controller concern when enabled
     class Railtie < ::Rails::Railtie
+      CONFIG_KEYS = %i[
+        discovery_url audience issuer leeway skip_paths
+        logger_tags error_renderer auto_include_controller
+        render_500_json rescue_pundit middleware_insert_before
+        middleware_insert_after auto_insert_bff_header_guard
+        bff_header_guard_insert_before bff_header_guard_insert_after
+        token_verify_options decoder_cache_limit token_env_key user_env_key
+        bff_header_guard_options
+      ].freeze
+
       config.verikloak = ActiveSupport::OrderedOptions.new
 
       # Apply configuration and insert middleware.
@@ -36,6 +46,7 @@ module Verikloak
         # @return [ActionDispatch::MiddlewareStackProxy] configured middleware stack
         def configure_middleware(app)
           apply_configuration(app)
+          configure_bff_library
 
           unless discovery_url_present?
             log_missing_discovery_url_warning
@@ -43,7 +54,7 @@ module Verikloak
           end
 
           stack = insert_base_middleware(app)
-          configure_bff_guard(stack)
+          configure_bff_guard(stack) if stack
 
           stack
         end
@@ -67,6 +78,33 @@ module Verikloak
           end
         end
 
+        # Apply configuration options to the verikloak-bff namespace.
+        # Supports hash-like and callable inputs.
+        #
+        # @param target [Module] Verikloak::BFF or Verikloak::Bff namespace
+        # @param options [Hash, Proc, #to_h]
+        # @return [void]
+        def apply_bff_configuration(target, options)
+          if options.respond_to?(:call)
+            target.configure(&options)
+            return
+          end
+
+          hash = options.respond_to?(:to_h) ? options.to_h : options
+          return unless hash.respond_to?(:each)
+
+          entries = hash.transform_keys(&:to_sym)
+
+          return if entries.empty?
+
+          target.configure do |config|
+            entries.each do |key, value|
+              writer = "#{key}="
+              config.public_send(writer, value) if config.respond_to?(writer)
+            end
+          end
+        end
+
         # Sync configuration from the Rails application into Verikloak::Rails.
         #
         # @param app [Rails::Application]
@@ -74,15 +112,31 @@ module Verikloak
         def apply_configuration(app)
           Verikloak::Rails.configure do |c|
             rails_cfg = app.config.verikloak
-            %i[discovery_url audience issuer leeway skip_paths
-               logger_tags error_renderer auto_include_controller
-               render_500_json rescue_pundit middleware_insert_before
-               middleware_insert_after auto_insert_bff_header_guard
-               bff_header_guard_insert_before bff_header_guard_insert_after].each do |key|
+            CONFIG_KEYS.each do |key|
               c.send("#{key}=", rails_cfg[key]) if rails_cfg.key?(key)
             end
             c.rescue_pundit = false if !rails_cfg.key?(:rescue_pundit) && defined?(::Verikloak::Pundit)
           end
+        end
+
+        # Configure the verikloak-bff library when options are supplied.
+        #
+        # @return [void]
+        def configure_bff_library
+          options = Verikloak::Rails.config.bff_header_guard_options
+          return if options.nil? || (options.respond_to?(:empty?) && options.empty?)
+
+          target = if defined?(::Verikloak::BFF) && ::Verikloak::BFF.respond_to?(:configure)
+                     ::Verikloak::BFF
+                   elsif defined?(::Verikloak::Bff) && ::Verikloak::Bff.respond_to?(:configure)
+                     ::Verikloak::Bff
+                   end
+
+          return unless target
+
+          apply_bff_configuration(target, options)
+        rescue StandardError => e
+          warn_with_fallback("[verikloak] Failed to apply BFF configuration: #{e.message}")
         end
 
         # Check if discovery_url is present and valid.

--- a/lib/verikloak/rails/version.rb
+++ b/lib/verikloak/rails/version.rb
@@ -2,6 +2,6 @@
 
 module Verikloak
   module Rails
-    VERSION = '0.2.7'
+    VERSION = '0.2.8'
   end
 end

--- a/spec/integration/pundit_integration_spec.rb
+++ b/spec/integration/pundit_integration_spec.rb
@@ -4,12 +4,7 @@ require 'spec_helper'
 require 'verikloak/rails'
 
 RSpec.describe 'Pundit integration auto-disable behavior' do
-  # Configuration keys to copy from Rails configuration
-  CONFIG_KEYS = %i[discovery_url audience issuer leeway skip_paths
-                   logger_tags error_renderer auto_include_controller
-                   render_500_json rescue_pundit middleware_insert_before
-                   middleware_insert_after auto_insert_bff_header_guard
-                   bff_header_guard_insert_before bff_header_guard_insert_after].freeze
+  CONFIG_KEYS = Verikloak::Rails::Railtie::CONFIG_KEYS
   before do
     Verikloak::Rails.reset!
   end


### PR DESCRIPTION
## Summary
- call `configure_bff_guard` from inside `configure_middleware` so the initializer no longer needs to handle the middleware stack directly