### PR TITLE
Only supports Verikloak::BFF::HeaderGuard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.3.0] - 2026-01-01
+
+### Changed
+- **BFF HeaderGuard detection**: Now only supports `Verikloak::BFF::HeaderGuard` (uppercase)
+  - Removed fallback support for `Verikloak::Bff::HeaderGuard` (lowercase)
+  - This simplifies the codebase and aligns with verikloak-bff's official namespace
+- `configure_bff_library` method simplified to only target `Verikloak::BFF` namespace
+
+### Added
+- Comprehensive test coverage for `configure_bff_guard` method
+  - Tests for default insertion position (before `Verikloak::Middleware`)
+  - Tests for custom insertion positions (`bff_header_guard_insert_before`, `bff_header_guard_insert_after`)
+  - Tests for disabled state (`auto_insert_bff_header_guard = false`)
+  - Tests for undefined `HeaderGuard` scenarios
+
+---
+
 ## [0.2.9] - 2025-12-31
 
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    verikloak-rails (0.2.9)
+    verikloak-rails (0.3.0)
       rack (>= 2.2, < 4.0)
       rails (>= 6.1, < 9.0)
       verikloak (>= 0.3.0, < 1.0.0)

--- a/lib/verikloak/rails/railtie.rb
+++ b/lib/verikloak/rails/railtie.rb
@@ -66,16 +66,16 @@ module Verikloak
         # @return [void]
         def configure_bff_guard(stack)
           return unless Verikloak::Rails.config.auto_insert_bff_header_guard
-          return unless defined?(::Verikloak::Bff::HeaderGuard)
+          return unless defined?(::Verikloak::BFF::HeaderGuard)
 
           guard_before = Verikloak::Rails.config.bff_header_guard_insert_before
           guard_after = Verikloak::Rails.config.bff_header_guard_insert_after
           if guard_before
-            stack.insert_before guard_before, ::Verikloak::Bff::HeaderGuard
+            stack.insert_before guard_before, ::Verikloak::BFF::HeaderGuard
           elsif guard_after
-            stack.insert_after guard_after, ::Verikloak::Bff::HeaderGuard
+            stack.insert_after guard_after, ::Verikloak::BFF::HeaderGuard
           else
-            stack.insert_before ::Verikloak::Middleware, ::Verikloak::Bff::HeaderGuard
+            stack.insert_before ::Verikloak::Middleware, ::Verikloak::BFF::HeaderGuard
           end
         end
 
@@ -126,16 +126,9 @@ module Verikloak
         def configure_bff_library
           options = Verikloak::Rails.config.bff_header_guard_options
           return if options.nil? || (options.respond_to?(:empty?) && options.empty?)
+          return unless defined?(::Verikloak::BFF) && ::Verikloak::BFF.respond_to?(:configure)
 
-          target = if defined?(::Verikloak::BFF) && ::Verikloak::BFF.respond_to?(:configure)
-                     ::Verikloak::BFF
-                   elsif defined?(::Verikloak::Bff) && ::Verikloak::Bff.respond_to?(:configure)
-                     ::Verikloak::Bff
-                   end
-
-          return unless target
-
-          apply_bff_configuration(target, options)
+          apply_bff_configuration(::Verikloak::BFF, options)
         rescue StandardError => e
           warn_with_fallback("[verikloak] Failed to apply BFF configuration: #{e.message}")
         end

--- a/lib/verikloak/rails/version.rb
+++ b/lib/verikloak/rails/version.rb
@@ -2,6 +2,6 @@
 
 module Verikloak
   module Rails
-    VERSION = '0.2.9'
+    VERSION = '0.3.0'
   end
 end


### PR DESCRIPTION
### Changed
- **BFF HeaderGuard detection**: Now only supports `Verikloak::BFF::HeaderGuard` (uppercase)
  - Removed fallback support for `Verikloak::Bff::HeaderGuard` (lowercase)
  - This simplifies the codebase and aligns with verikloak-bff's official namespace
- `configure_bff_library` method simplified to only target `Verikloak::BFF` namespace

### Added
- Comprehensive test coverage for `configure_bff_guard` method
  - Tests for default insertion position (before `Verikloak::Middleware`)
  - Tests for custom insertion positions (`bff_header_guard_insert_before`, `bff_header_guard_insert_after`)
  - Tests for disabled state (`auto_insert_bff_header_guard = false`)
  - Tests for undefined `HeaderGuard` scenarios