### PR TITLE
Update railtie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.3.1] - 2026-01-01
+
+### Added
+- **API mode support**: `auto_include_controller` now automatically includes
+  `Verikloak::Rails::Controller` in both `ActionController::Base` and `ActionController::API`
+  - Rails API-only applications (`rails new myapp --api`) now work out of the box
+  - Skip logic prevents duplicate inclusion when controller already includes the concern
+
+### Changed
+- **Generator template improved**: `initializer.rb.erb` now includes:
+  - Descriptive comments for each configuration option
+  - ENV variable support for `auto_include_controller` (`VERIKLOAK_AUTO_INCLUDE`)
+  - ENV variable prefix changed from `VERIKLOAK_AUDIENCE` to `KEYCLOAK_AUDIENCE` for consistency
+
+### Documentation
+- README updated with API mode usage example
+
+---
+
 ## [0.3.0] - 2026-01-01
 
 ### Changed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    verikloak-rails (0.3.0)
+    verikloak-rails (0.3.1)
       rack (>= 2.2, < 4.0)
       rails (>= 6.1, < 9.0)
       verikloak (>= 0.3.0, < 1.0.0)

--- a/README.md
+++ b/README.md
@@ -108,6 +108,16 @@ class ApplicationController < ActionController::Base
 end
 ```
 
+### API Mode Support
+Both `ActionController::Base` and `ActionController::API` are supported. The controller concern is automatically included in both when `auto_include_controller` is enabled (default).
+
+```ruby
+# Works automatically with Rails API mode (rails new myapp --api)
+class ApplicationController < ActionController::API
+  # Verikloak::Rails::Controller is auto-included
+end
+```
+
 ## Middleware
 ### Inserted Middleware
 | Component | Inserted relative to | Purpose |

--- a/lib/generators/verikloak/install/templates/initializer.rb.erb
+++ b/lib/generators/verikloak/install/templates/initializer.rb.erb
@@ -1,14 +1,29 @@
 # frozen_string_literal: true
 
 Rails.application.configure do
+  # Discovery URL (required)
   config.verikloak.discovery_url = ENV.fetch('KEYCLOAK_DISCOVERY_URL', nil)
-  config.verikloak.audience      = ENV.fetch('VERIKLOAK_AUDIENCE', 'rails-api')
-  config.verikloak.issuer        = ENV.fetch('VERIKLOAK_ISSUER', nil)
-  config.verikloak.leeway        = Integer(ENV.fetch('VERIKLOAK_LEEWAY', '60'))
-  config.verikloak.skip_paths    = %w[/up /health /rails/health]
 
+  # Audience validation (optional but recommended)
+  config.verikloak.audience = ENV.fetch('KEYCLOAK_AUDIENCE', 'rails-api')
+
+  # Issuer validation (optional, derived from discovery_url if not set)
+  config.verikloak.issuer = ENV.fetch('KEYCLOAK_ISSUER', nil)
+
+  # JWT clock skew tolerance in seconds
+  config.verikloak.leeway = Integer(ENV.fetch('VERIKLOAK_LEEWAY', '60'))
+
+  # Paths to skip authentication (health checks, etc.)
+  config.verikloak.skip_paths = %w[/up /health /rails/health]
+
+  # Request ID and subject in logs
   config.verikloak.logger_tags = %i[request_id sub]
-  config.verikloak.auto_include_controller = true
+
+  # Auto-include controller concern
+  # Set to false if you manually include Verikloak::Rails::Controller
+  config.verikloak.auto_include_controller = ENV.fetch('VERIKLOAK_AUTO_INCLUDE', 'true') == 'true'
+
+  # Render detailed 500 errors (development only recommended)
   config.verikloak.render_500_json = ENV.fetch('VERIKLOAK_RENDER_500', 'false') == 'true'
 
   # Optional Pundit rescue (403 JSON). Leave commented so `verikloak-pundit`

--- a/lib/verikloak/rails/railtie.rb
+++ b/lib/verikloak/rails/railtie.rb
@@ -31,10 +31,16 @@ module Verikloak
       end
 
       # Optionally include the controller concern when ActionController loads.
+      # Supports both ActionController::Base and ActionController::API (API mode).
+      # Skips inclusion if the controller already includes the concern.
       # @return [void]
       initializer 'verikloak.controller' do |_app|
-        ActiveSupport.on_load(:action_controller_base) do
-          include Verikloak::Rails::Controller if Verikloak::Rails.config.auto_include_controller
+        %i[action_controller_base action_controller_api].each do |hook|
+          ActiveSupport.on_load(hook) do
+            next if include?(Verikloak::Rails::Controller) # Already included, skip
+
+            include Verikloak::Rails::Controller if Verikloak::Rails.config.auto_include_controller
+          end
         end
       end
 

--- a/lib/verikloak/rails/version.rb
+++ b/lib/verikloak/rails/version.rb
@@ -2,6 +2,6 @@
 
 module Verikloak
   module Rails
-    VERSION = '0.3.0'
+    VERSION = '0.3.1'
   end
 end

--- a/spec/generators/verikloak/install_generator_spec.rb
+++ b/spec/generators/verikloak/install_generator_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'fileutils'
+require 'stringio'
+require 'rails/generators'
+require 'generators/verikloak/install/install_generator'
+
+RSpec.describe Verikloak::Generators::InstallGenerator, type: :generator do
+  let(:destination_root) { File.expand_path('../../tmp/generator_test', __dir__) }
+  let(:initializer_path) { File.join(destination_root, 'config/initializers/verikloak.rb') }
+
+  before do
+    FileUtils.rm_rf(destination_root)
+    FileUtils.mkdir_p(destination_root)
+  end
+
+  after do
+    FileUtils.rm_rf(destination_root)
+  end
+
+  def run_generator(args = [], config = {})
+    capture_output do
+      described_class.start(args, config.merge(destination_root: destination_root))
+    end
+  end
+
+  def capture_output
+    stdout = StringIO.new
+    original_stdout = $stdout
+    $stdout = stdout
+    yield
+    stdout.string
+  ensure
+    $stdout = original_stdout
+  end
+
+  describe '#create_initializer' do
+    it 'creates config/initializers/verikloak.rb with valid Ruby syntax' do
+      run_generator
+
+      expect(File.exist?(initializer_path)).to be true
+
+      content = File.read(initializer_path)
+      expect { RubyVM::InstructionSequence.compile(content) }.not_to raise_error
+    end
+
+    it 'generates initializer with all expected configuration options' do
+      run_generator
+
+      content = File.read(initializer_path)
+
+      # Structure
+      expect(content).to include('Rails.application.configure do')
+
+      # Required settings
+      expect(content).to include("config.verikloak.discovery_url = ENV.fetch('KEYCLOAK_DISCOVERY_URL', nil)")
+
+      # Optional settings with defaults
+      expect(content).to include("config.verikloak.audience = ENV.fetch('KEYCLOAK_AUDIENCE', 'rails-api')")
+      expect(content).to include("config.verikloak.issuer = ENV.fetch('KEYCLOAK_ISSUER', nil)")
+      expect(content).to include("config.verikloak.leeway = Integer(ENV.fetch('VERIKLOAK_LEEWAY', '60'))")
+      expect(content).to include('config.verikloak.skip_paths = %w[/up /health /rails/health]')
+      expect(content).to include('config.verikloak.logger_tags = %i[request_id sub]')
+
+      # Boolean settings via ENV
+      expect(content).to include("config.verikloak.auto_include_controller = ENV.fetch('VERIKLOAK_AUTO_INCLUDE', 'true') == 'true'")
+      expect(content).to include("config.verikloak.render_500_json = ENV.fetch('VERIKLOAK_RENDER_500', 'false') == 'true'")
+
+      # Commented optional setting
+      expect(content).to include("# config.verikloak.rescue_pundit = ENV.fetch('VERIKLOAK_RESCUE_PUNDIT', 'true') == 'true'")
+    end
+  end
+
+  describe '#say_next_steps' do
+    it 'outputs completion message with setup instructions' do
+      output = run_generator
+
+      expect(output).to include('verikloak: initializer created')
+      expect(output).to include('Next steps:')
+      expect(output).to include('discovery_url')
+      expect(output).to include('verikloak-bff')
+      expect(output).to include('verikloak-pundit')
+    end
+  end
+end

--- a/spec/integration/rails_integration_spec.rb
+++ b/spec/integration/rails_integration_spec.rb
@@ -8,17 +8,12 @@ require 'active_support/tagged_logging'
 # Ensure the stubbed base middleware is found before the Railtie requires it.
 $LOAD_PATH.unshift File.expand_path('../stubs', __dir__)
 
+# Load shared stubs for error classes
+require_relative '../support/verikloak_stubs'
+
 require 'rails'
 require 'action_controller/railtie'
 require 'rack/test'
-
-# Define Verikloak module and stubs before requiring verikloak-rails
-module ::Verikloak; end unless defined?(::Verikloak)
-
-# Stub missing error classes that the real middleware expects
-unless defined?(::Verikloak::DiscoveryError)
-  class ::Verikloak::DiscoveryError < StandardError; end
-end
 
 # Stub the Discovery class that the real middleware expects
 unless defined?(::Verikloak::Middleware::Discovery)
@@ -28,32 +23,11 @@ unless defined?(::Verikloak::Middleware::Discovery)
         def initialize(*); end
         def call(*); end
       end
-      
-      # Stub missing error classes
-      class MiddlewareError < StandardError; end
     end
   end
-end
-
-# Define Verikloak::Error for controller rescue behavior if not present.
-unless defined?(::Verikloak::Error)
-  class ::Verikloak::Error < StandardError
-    attr_reader :code
-    def initialize(code = 'unauthorized', message = nil)
-      @code = code
-      super(message || code)
-    end
-  end
-end
-
-# Define a minimal Pundit::NotAuthorizedError to exercise the rescue path
-module ::Pundit; end unless defined?(::Pundit)
-unless defined?(::Pundit::NotAuthorizedError)
-  class ::Pundit::NotAuthorizedError < StandardError; end
 end
 
 # Define a minimal BFF header guard to exercise auto-insertion behavior.
-module ::Verikloak; end unless defined?(::Verikloak)
 module ::Verikloak::BFF; end unless defined?(::Verikloak::BFF)
 unless defined?(::Verikloak::BFF::HeaderGuard)
   class ::Verikloak::BFF::HeaderGuard

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/setup'
 
 # Enable SimpleCov coverage reporting when CI sets SIMPLECOV=true

--- a/spec/stubs/verikloak/middleware.rb
+++ b/spec/stubs/verikloak/middleware.rb
@@ -3,10 +3,10 @@
 # Minimal stub of the base Verikloak middleware for integration tests.
 # It simulates successful authentication when a bearer token 'valid' is present.
 
-module Verikloak
-  # Stub missing error classes that the real middleware expects
-  class DiscoveryError < StandardError; end
+# Load shared stubs for error classes
+require_relative '../../support/verikloak_stubs'
 
+module Verikloak
   class Middleware
     # Stub missing error classes
     class MiddlewareError < StandardError; end

--- a/spec/support/verikloak_stubs.rb
+++ b/spec/support/verikloak_stubs.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# Shared stubs for verikloak base gem classes.
+# These stubs allow testing verikloak-rails without requiring the actual verikloak gem.
+
+module ::Verikloak; end unless defined?(::Verikloak)
+
+# Stub for Verikloak::Error - the base error class used throughout verikloak
+unless defined?(::Verikloak::Error)
+  class ::Verikloak::Error < StandardError
+    attr_reader :code
+
+    def initialize(code = 'unauthorized', message = nil)
+      @code = code
+      super(message || code)
+    end
+  end
+end
+
+# Stub for Verikloak::DiscoveryError - raised when OIDC discovery fails
+unless defined?(::Verikloak::DiscoveryError)
+  class ::Verikloak::DiscoveryError < ::Verikloak::Error; end
+end
+
+# Stub for Pundit::NotAuthorizedError - used for Pundit integration tests
+module ::Pundit; end unless defined?(::Pundit)
+unless defined?(::Pundit::NotAuthorizedError)
+  class ::Pundit::NotAuthorizedError < StandardError; end
+end

--- a/spec/verikloak/rails/controller_spec.rb
+++ b/spec/verikloak/rails/controller_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require_relative '../../support/verikloak_stubs'
 require 'verikloak/rails'
 require 'verikloak/rails/controller'
 


### PR DESCRIPTION
### Added
- **API mode support**: `auto_include_controller` now automatically includes
  `Verikloak::Rails::Controller` in both `ActionController::Base` and `ActionController::API`
  - Rails API-only applications (`rails new myapp --api`) now work out of the box
  - Skip logic prevents duplicate inclusion when controller already includes the concern

### Changed
- **Generator template improved**: `initializer.rb.erb` now includes:
  - Descriptive comments for each configuration option
  - ENV variable support for `auto_include_controller` (`VERIKLOAK_AUTO_INCLUDE`)
  - ENV variable prefix changed from `VERIKLOAK_AUDIENCE` to `KEYCLOAK_AUDIENCE` for consistency

### Documentation
- README updated with API mode usage example