### PR TITLE
Change railtie process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.3.2] - 2026-01-01
+
+### Changed
+- **BFF HeaderGuard safe insertion**: Railtie now validates BFF configuration before inserting `HeaderGuard`. If `trusted_proxies` is not configured (and `disabled` is not set to `true`), insertion is skipped with a warning instead of raising an error.
+  - This allows applications to start during initial setup before BFF configuration is complete.
+  - A clear warning message guides users to either configure `trusted_proxies` or set `disabled: true`.
+
+### Added
+- `bff_configuration_valid?` helper method in Railtie to check BFF configuration validity.
+
+---
+
 ## [0.3.1] - 2026-01-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **BFF HeaderGuard safe insertion**: Railtie now validates BFF configuration before inserting `HeaderGuard`. If `trusted_proxies` is not configured (and `disabled` is not set to `true`), insertion is skipped with a warning instead of raising an error.
   - This allows applications to start during initial setup before BFF configuration is complete.
-  - A clear warning message guides users to either configure `trusted_proxies` or set `disabled: true`.
+  - A clear warning message guides users to configure `trusted_proxies` to enable header validation.
+  - When `disabled: true` is set, HeaderGuard is inserted but internally disabled.
+- **Railtie refactoring**: Extracted BFF configuration logic into `BffConfigurator` module and logging utilities into `RailtieLogger` module to improve maintainability.
 
 ### Added
-- `bff_configuration_valid?` helper method in Railtie to check BFF configuration validity.
+- `BffConfigurator` module for BFF-related middleware configuration.
+- `RailtieLogger` module for consistent logging across Railtie operations.
+- Comprehensive test coverage for `BffConfigurator.configuration_valid?` method.
 
 ---
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    verikloak-rails (0.3.1)
+    verikloak-rails (0.3.2)
       rack (>= 2.2, < 4.0)
       rails (>= 6.1, < 9.0)
       verikloak (>= 0.3.0, < 1.0.0)

--- a/lib/verikloak/rails/bff_configurator.rb
+++ b/lib/verikloak/rails/bff_configurator.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+module Verikloak
+  module Rails
+    # Handles BFF (Backend-for-Frontend) middleware configuration.
+    # Extracted from Railtie to maintain class size limits.
+    module BffConfigurator
+      module_function
+
+      # Insert the optional HeaderGuard middleware when verikloak-bff is present.
+      # Skips insertion with a warning if trusted_proxies is not configured and
+      # disabled is not explicitly set to true.
+      #
+      # @param stack [ActionDispatch::MiddlewareStackProxy]
+      # @return [void]
+      def configure_bff_guard(stack)
+        return unless Verikloak::Rails.config.auto_insert_bff_header_guard
+        return unless defined?(::Verikloak::BFF::HeaderGuard)
+
+        unless configuration_valid?
+          RailtieLogger.warn(
+            '[verikloak] Skipping BFF::HeaderGuard insertion: trusted_proxies not configured. ' \
+            'Set trusted_proxies in bff_header_guard_options to enable header validation.'
+          )
+          return
+        end
+
+        insert_header_guard(stack)
+      end
+
+      # Configure the verikloak-bff library when options are supplied.
+      #
+      # @return [void]
+      def configure_library
+        options = Verikloak::Rails.config.bff_header_guard_options
+        return if options.nil? || (options.respond_to?(:empty?) && options.empty?)
+        return unless defined?(::Verikloak::BFF) && ::Verikloak::BFF.respond_to?(:configure)
+
+        apply_configuration(::Verikloak::BFF, options)
+      rescue StandardError => e
+        RailtieLogger.warn("[verikloak] Failed to apply BFF configuration: #{e.message}")
+      end
+
+      # Check if BFF configuration is valid for middleware insertion.
+      # Returns true if:
+      #   - disabled: true is set (HeaderGuard will be inserted but internally disabled), OR
+      #   - trusted_proxies is configured with at least one entry
+      #
+      # @return [Boolean]
+      def configuration_valid?
+        return true unless defined?(::Verikloak::BFF)
+        return true unless ::Verikloak::BFF.respond_to?(:config)
+
+        bff_config = ::Verikloak::BFF.config
+
+        # If disabled is explicitly set to true, allow insertion
+        # (HeaderGuard will be inserted but internally disabled)
+        return true if bff_config.respond_to?(:disabled) && bff_config.disabled
+
+        # For legacy versions without trusted_proxies method, allow insertion
+        return true unless bff_config.respond_to?(:trusted_proxies)
+
+        # Require trusted_proxies to be a non-empty Array
+        proxies = bff_config.trusted_proxies
+        proxies.is_a?(Array) && !proxies.empty?
+      end
+
+      # Insert HeaderGuard middleware into the stack.
+      #
+      # @param stack [ActionDispatch::MiddlewareStackProxy]
+      # @return [void]
+      def insert_header_guard(stack)
+        guard_before = Verikloak::Rails.config.bff_header_guard_insert_before
+        guard_after = Verikloak::Rails.config.bff_header_guard_insert_after
+
+        if guard_before
+          stack.insert_before guard_before, ::Verikloak::BFF::HeaderGuard
+        elsif guard_after
+          stack.insert_after guard_after, ::Verikloak::BFF::HeaderGuard
+        else
+          stack.insert_before ::Verikloak::Middleware, ::Verikloak::BFF::HeaderGuard
+        end
+      end
+
+      # Apply configuration options to the verikloak-bff namespace.
+      # Supports hash-like and callable inputs.
+      #
+      # @param target [Module] Verikloak::BFF namespace
+      # @param options [Hash, Proc, #to_h]
+      # @return [void]
+      def apply_configuration(target, options)
+        if options.respond_to?(:call)
+          target.configure(&options)
+          return
+        end
+
+        hash = options.respond_to?(:to_h) ? options.to_h : options
+        return unless hash.respond_to?(:each)
+
+        entries = hash.transform_keys(&:to_sym)
+        return if entries.empty?
+
+        target.configure do |config|
+          entries.each do |key, value|
+            writer = "#{key}="
+            config.public_send(writer, value) if config.respond_to?(writer)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/verikloak/rails/railtie.rb
+++ b/lib/verikloak/rails/railtie.rb
@@ -2,6 +2,8 @@
 
 require 'rails/railtie'
 require 'verikloak/middleware'
+require_relative 'railtie_logger'
+require_relative 'bff_configurator'
 
 module Verikloak
   module Rails
@@ -53,7 +55,7 @@ module Verikloak
         # @return [ActionDispatch::MiddlewareStackProxy] configured middleware stack
         def configure_middleware(app)
           apply_configuration(app)
-          configure_bff_library
+          BffConfigurator.configure_library
 
           unless discovery_url_present?
             log_missing_discovery_url_warning
@@ -61,117 +63,9 @@ module Verikloak
           end
 
           stack = insert_base_middleware(app)
-          configure_bff_guard(stack) if stack
+          BffConfigurator.configure_bff_guard(stack) if stack
 
           stack
-        end
-
-        # Insert the optional HeaderGuard middleware when verikloak-bff is present.
-        # Skips insertion with a warning if trusted_proxies is not configured and
-        # disabled is not explicitly set to true.
-        #
-        # @param stack [ActionDispatch::MiddlewareStackProxy]
-        # @return [void]
-        def configure_bff_guard(stack)
-          return unless Verikloak::Rails.config.auto_insert_bff_header_guard
-          return unless defined?(::Verikloak::BFF::HeaderGuard)
-
-          # Check if BFF configuration is valid before inserting
-          unless bff_configuration_valid?
-            warn_with_fallback(
-              '[verikloak] Skipping BFF::HeaderGuard insertion: trusted_proxies not configured. ' \
-              'Set trusted_proxies in bff_header_guard_options to enable header validation.'
-            )
-            return
-          end
-
-          guard_before = Verikloak::Rails.config.bff_header_guard_insert_before
-          guard_after = Verikloak::Rails.config.bff_header_guard_insert_after
-          if guard_before
-            stack.insert_before guard_before, ::Verikloak::BFF::HeaderGuard
-          elsif guard_after
-            stack.insert_after guard_after, ::Verikloak::BFF::HeaderGuard
-          else
-            stack.insert_before ::Verikloak::Middleware, ::Verikloak::BFF::HeaderGuard
-          end
-        end
-
-        # Check if BFF configuration is valid for middleware insertion.
-        # Returns true if:
-        #   - disabled: true is set (HeaderGuard will be inserted but internally disabled), OR
-        #   - trusted_proxies is configured with at least one entry
-        #
-        # @return [Boolean]
-        def bff_configuration_valid?
-          return true unless defined?(::Verikloak::BFF)
-          return true unless ::Verikloak::BFF.respond_to?(:config)
-
-          bff_config = ::Verikloak::BFF.config
-
-          # If disabled is explicitly set to true, allow insertion
-          # (HeaderGuard will be inserted but internally disabled)
-          return true if bff_config.respond_to?(:disabled) && bff_config.disabled
-
-          # For legacy versions without trusted_proxies method, allow insertion
-          return true unless bff_config.respond_to?(:trusted_proxies)
-
-          # Require trusted_proxies to be a non-empty Array
-          proxies = bff_config.trusted_proxies
-          proxies.is_a?(Array) && !proxies.empty?
-        end
-
-        # Apply configuration options to the verikloak-bff namespace.
-        # Supports hash-like and callable inputs.
-        #
-        # @param target [Module] Verikloak::BFF or Verikloak::Bff namespace
-        # @param options [Hash, Proc, #to_h]
-        # @return [void]
-        def apply_bff_configuration(target, options)
-          if options.respond_to?(:call)
-            target.configure(&options)
-            return
-          end
-
-          hash = options.respond_to?(:to_h) ? options.to_h : options
-          return unless hash.respond_to?(:each)
-
-          entries = hash.transform_keys(&:to_sym)
-
-          return if entries.empty?
-
-          target.configure do |config|
-            entries.each do |key, value|
-              writer = "#{key}="
-              config.public_send(writer, value) if config.respond_to?(writer)
-            end
-          end
-        end
-
-        # Sync configuration from the Rails application into Verikloak::Rails.
-        #
-        # @param app [Rails::Application]
-        # @return [void]
-        def apply_configuration(app)
-          Verikloak::Rails.configure do |c|
-            rails_cfg = app.config.verikloak
-            CONFIG_KEYS.each do |key|
-              c.send("#{key}=", rails_cfg[key]) if rails_cfg.key?(key)
-            end
-            c.rescue_pundit = false if !rails_cfg.key?(:rescue_pundit) && defined?(::Verikloak::Pundit)
-          end
-        end
-
-        # Configure the verikloak-bff library when options are supplied.
-        #
-        # @return [void]
-        def configure_bff_library
-          options = Verikloak::Rails.config.bff_header_guard_options
-          return if options.nil? || (options.respond_to?(:empty?) && options.empty?)
-          return unless defined?(::Verikloak::BFF) && ::Verikloak::BFF.respond_to?(:configure)
-
-          apply_bff_configuration(::Verikloak::BFF, options)
-        rescue StandardError => e
-          warn_with_fallback("[verikloak] Failed to apply BFF configuration: #{e.message}")
         end
 
         # Check if discovery_url is present and valid.
@@ -193,7 +87,21 @@ module Verikloak
         # @return [void]
         def log_missing_discovery_url_warning
           message = '[verikloak] discovery_url is not configured; skipping middleware insertion.'
-          warn_with_fallback(message)
+          RailtieLogger.warn(message)
+        end
+
+        # Sync configuration from the Rails application into Verikloak::Rails.
+        #
+        # @param app [Rails::Application]
+        # @return [void]
+        def apply_configuration(app)
+          Verikloak::Rails.configure do |c|
+            rails_cfg = app.config.verikloak
+            CONFIG_KEYS.each do |key|
+              c.send("#{key}=", rails_cfg[key]) if rails_cfg.key?(key)
+            end
+            c.rescue_pundit = false if !rails_cfg.key?(:rescue_pundit) && defined?(::Verikloak::Pundit)
+          end
         end
 
         # Insert the base Verikloak::Middleware into the application middleware stack.
@@ -278,26 +186,7 @@ module Verikloak
         def log_middleware_insertion_warning(candidate, error)
           candidate_name = candidate.is_a?(Class) ? candidate.name : candidate.class.name
           message = "[verikloak] Unable to insert after #{candidate_name}: #{error.message}"
-          warn_with_fallback(message)
-        end
-
-        # Resolve the logger instance used for warnings, if present.
-        # @return [Object, nil]
-        def rails_logger
-          return unless defined?(::Rails) && ::Rails.respond_to?(:logger)
-
-          ::Rails.logger
-        end
-
-        # Log a warning using Rails.logger when available, otherwise fall back to Kernel#warn.
-        # @param message [String]
-        # @return [void]
-        def warn_with_fallback(message)
-          if (logger = rails_logger)
-            logger.warn(message)
-          else
-            warn(message)
-          end
+          RailtieLogger.warn(message)
         end
       end
     end

--- a/lib/verikloak/rails/railtie_logger.rb
+++ b/lib/verikloak/rails/railtie_logger.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Verikloak
+  module Rails
+    # Logging utilities for Railtie operations.
+    # Provides consistent warning output across Rails versions.
+    module RailtieLogger
+      module_function
+
+      # Log a warning using Rails.logger when available, otherwise fall back to Kernel#warn.
+      # @param message [String]
+      # @return [void]
+      def warn(message)
+        if (logger = rails_logger)
+          logger.warn(message)
+        else
+          Kernel.warn(message)
+        end
+      end
+
+      # Resolve the logger instance used for warnings, if present.
+      # @return [Object, nil]
+      def rails_logger
+        return unless defined?(::Rails) && ::Rails.respond_to?(:logger)
+
+        ::Rails.logger
+      end
+    end
+  end
+end

--- a/lib/verikloak/rails/version.rb
+++ b/lib/verikloak/rails/version.rb
@@ -2,6 +2,6 @@
 
 module Verikloak
   module Rails
-    VERSION = '0.3.1'
+    VERSION = '0.3.2'
   end
 end

--- a/spec/verikloak/rails/railtie_spec.rb
+++ b/spec/verikloak/rails/railtie_spec.rb
@@ -134,7 +134,6 @@ RSpec.describe Verikloak::Rails::Railtie, type: :railtie do
   end
 
   describe '.configure_bff_guard' do
-    let(:railtie) { described_class }
     let(:middleware_stack) { double('MiddlewareStack') }
 
     before do
@@ -159,7 +158,7 @@ RSpec.describe Verikloak::Rails::Railtie, type: :railtie do
           expect(middleware_stack).to receive(:insert_before)
             .with(::Verikloak::Middleware, ::Verikloak::BFF::HeaderGuard)
 
-          railtie.send(:configure_bff_guard, middleware_stack)
+          Verikloak::Rails::BffConfigurator.configure_bff_guard(middleware_stack)
         end
 
         it 'inserts HeaderGuard before specified middleware when bff_header_guard_insert_before is set' do
@@ -174,7 +173,7 @@ RSpec.describe Verikloak::Rails::Railtie, type: :railtie do
           expect(middleware_stack).to receive(:insert_before)
             .with(custom_middleware, ::Verikloak::BFF::HeaderGuard)
 
-          railtie.send(:configure_bff_guard, middleware_stack)
+          Verikloak::Rails::BffConfigurator.configure_bff_guard(middleware_stack)
         end
 
         it 'inserts HeaderGuard after specified middleware when bff_header_guard_insert_after is set' do
@@ -190,7 +189,7 @@ RSpec.describe Verikloak::Rails::Railtie, type: :railtie do
           expect(middleware_stack).to receive(:insert_after)
             .with(custom_middleware, ::Verikloak::BFF::HeaderGuard)
 
-          railtie.send(:configure_bff_guard, middleware_stack)
+          Verikloak::Rails::BffConfigurator.configure_bff_guard(middleware_stack)
         end
       end
 
@@ -205,7 +204,7 @@ RSpec.describe Verikloak::Rails::Railtie, type: :railtie do
           expect(middleware_stack).not_to receive(:insert_before)
           expect(middleware_stack).not_to receive(:insert_after)
 
-          railtie.send(:configure_bff_guard, middleware_stack)
+          Verikloak::Rails::BffConfigurator.configure_bff_guard(middleware_stack)
         end
       end
     end
@@ -222,13 +221,12 @@ RSpec.describe Verikloak::Rails::Railtie, type: :railtie do
         expect(middleware_stack).not_to receive(:insert_before)
         expect(middleware_stack).not_to receive(:insert_after)
 
-        railtie.send(:configure_bff_guard, middleware_stack)
+        Verikloak::Rails::BffConfigurator.configure_bff_guard(middleware_stack)
       end
     end
   end
 
-  describe '.bff_configuration_valid?' do
-    let(:railtie) { described_class }
+  describe 'BffConfigurator.configuration_valid?' do
     let(:bff_config) { double('BffConfig') }
 
     before do
@@ -242,7 +240,7 @@ RSpec.describe Verikloak::Rails::Railtie, type: :railtie do
     context 'when Verikloak::BFF is not defined' do
       it 'returns true' do
         hide_const('::Verikloak::BFF')
-        expect(railtie.send(:bff_configuration_valid?)).to be true
+        expect(Verikloak::Rails::BffConfigurator.configuration_valid?).to be true
       end
     end
 
@@ -251,7 +249,7 @@ RSpec.describe Verikloak::Rails::Railtie, type: :railtie do
         allow(bff_config).to receive(:respond_to?).with(:disabled).and_return(true)
         allow(bff_config).to receive(:disabled).and_return(true)
 
-        expect(railtie.send(:bff_configuration_valid?)).to be true
+        expect(Verikloak::Rails::BffConfigurator.configuration_valid?).to be true
       end
     end
 
@@ -265,7 +263,7 @@ RSpec.describe Verikloak::Rails::Railtie, type: :railtie do
         it 'returns true' do
           allow(bff_config).to receive(:respond_to?).with(:trusted_proxies).and_return(false)
 
-          expect(railtie.send(:bff_configuration_valid?)).to be true
+          expect(Verikloak::Rails::BffConfigurator.configuration_valid?).to be true
         end
       end
 
@@ -274,7 +272,7 @@ RSpec.describe Verikloak::Rails::Railtie, type: :railtie do
           allow(bff_config).to receive(:respond_to?).with(:trusted_proxies).and_return(true)
           allow(bff_config).to receive(:trusted_proxies).and_return(['10.0.0.0/8'])
 
-          expect(railtie.send(:bff_configuration_valid?)).to be true
+          expect(Verikloak::Rails::BffConfigurator.configuration_valid?).to be true
         end
       end
 
@@ -283,7 +281,7 @@ RSpec.describe Verikloak::Rails::Railtie, type: :railtie do
           allow(bff_config).to receive(:respond_to?).with(:trusted_proxies).and_return(true)
           allow(bff_config).to receive(:trusted_proxies).and_return([])
 
-          expect(railtie.send(:bff_configuration_valid?)).to be false
+          expect(Verikloak::Rails::BffConfigurator.configuration_valid?).to be false
         end
       end
 
@@ -292,7 +290,7 @@ RSpec.describe Verikloak::Rails::Railtie, type: :railtie do
           allow(bff_config).to receive(:respond_to?).with(:trusted_proxies).and_return(true)
           allow(bff_config).to receive(:trusted_proxies).and_return(nil)
 
-          expect(railtie.send(:bff_configuration_valid?)).to be false
+          expect(Verikloak::Rails::BffConfigurator.configuration_valid?).to be false
         end
       end
 
@@ -301,21 +299,20 @@ RSpec.describe Verikloak::Rails::Railtie, type: :railtie do
           allow(bff_config).to receive(:respond_to?).with(:trusted_proxies).and_return(true)
           allow(bff_config).to receive(:trusted_proxies).and_return(Set.new(['10.0.0.0/8']))
 
-          expect(railtie.send(:bff_configuration_valid?)).to be false
+          expect(Verikloak::Rails::BffConfigurator.configuration_valid?).to be false
         end
 
         it 'returns false for String' do
           allow(bff_config).to receive(:respond_to?).with(:trusted_proxies).and_return(true)
           allow(bff_config).to receive(:trusted_proxies).and_return('10.0.0.0/8')
 
-          expect(railtie.send(:bff_configuration_valid?)).to be false
+          expect(Verikloak::Rails::BffConfigurator.configuration_valid?).to be false
         end
       end
     end
   end
 
-  describe '.configure_bff_guard with bff_configuration_valid? integration' do
-    let(:railtie) { described_class }
+  describe '.configure_bff_guard with configuration_valid? integration' do
     let(:middleware_stack) { double('MiddlewareStack') }
     let(:bff_config) { double('BffConfig') }
 
@@ -345,12 +342,12 @@ RSpec.describe Verikloak::Rails::Railtie, type: :railtie do
         expect(middleware_stack).not_to receive(:insert_before)
         expect(middleware_stack).not_to receive(:insert_after)
 
-        expect(railtie).to receive(:warn_with_fallback).with(
+        expect(Verikloak::Rails::RailtieLogger).to receive(:warn).with(
           '[verikloak] Skipping BFF::HeaderGuard insertion: trusted_proxies not configured. ' \
           'Set trusted_proxies in bff_header_guard_options to enable header validation.'
         )
 
-        railtie.send(:configure_bff_guard, middleware_stack)
+        Verikloak::Rails::BffConfigurator.configure_bff_guard(middleware_stack)
       end
     end
 
@@ -364,7 +361,7 @@ RSpec.describe Verikloak::Rails::Railtie, type: :railtie do
         expect(middleware_stack).to receive(:insert_before)
           .with(::Verikloak::Middleware, ::Verikloak::BFF::HeaderGuard)
 
-        railtie.send(:configure_bff_guard, middleware_stack)
+        Verikloak::Rails::BffConfigurator.configure_bff_guard(middleware_stack)
       end
     end
 
@@ -380,7 +377,7 @@ RSpec.describe Verikloak::Rails::Railtie, type: :railtie do
         expect(middleware_stack).to receive(:insert_before)
           .with(::Verikloak::Middleware, ::Verikloak::BFF::HeaderGuard)
 
-        railtie.send(:configure_bff_guard, middleware_stack)
+        Verikloak::Rails::BffConfigurator.configure_bff_guard(middleware_stack)
       end
     end
   end

--- a/spec/verikloak/rails/railtie_spec.rb
+++ b/spec/verikloak/rails/railtie_spec.rb
@@ -227,6 +227,164 @@ RSpec.describe Verikloak::Rails::Railtie, type: :railtie do
     end
   end
 
+  describe '.bff_configuration_valid?' do
+    let(:railtie) { described_class }
+    let(:bff_config) { double('BffConfig') }
+
+    before do
+      stub_const('::Verikloak::BFF', Module.new)
+      allow(::Verikloak::BFF).to receive(:respond_to?).and_return(false)
+      allow(::Verikloak::BFF).to receive(:respond_to?).with(:config).and_return(true)
+      allow(::Verikloak::BFF).to receive(:respond_to?).with(:config, true).and_return(true)
+      allow(::Verikloak::BFF).to receive(:config).and_return(bff_config)
+    end
+
+    context 'when Verikloak::BFF is not defined' do
+      it 'returns true' do
+        hide_const('::Verikloak::BFF')
+        expect(railtie.send(:bff_configuration_valid?)).to be true
+      end
+    end
+
+    context 'when disabled is true' do
+      it 'returns true (HeaderGuard will be inserted but internally disabled)' do
+        allow(bff_config).to receive(:respond_to?).with(:disabled).and_return(true)
+        allow(bff_config).to receive(:disabled).and_return(true)
+
+        expect(railtie.send(:bff_configuration_valid?)).to be true
+      end
+    end
+
+    context 'when disabled is false or nil' do
+      before do
+        allow(bff_config).to receive(:respond_to?).with(:disabled).and_return(true)
+        allow(bff_config).to receive(:disabled).and_return(false)
+      end
+
+      context 'when trusted_proxies is not supported (legacy version)' do
+        it 'returns true' do
+          allow(bff_config).to receive(:respond_to?).with(:trusted_proxies).and_return(false)
+
+          expect(railtie.send(:bff_configuration_valid?)).to be true
+        end
+      end
+
+      context 'when trusted_proxies is a non-empty Array' do
+        it 'returns true' do
+          allow(bff_config).to receive(:respond_to?).with(:trusted_proxies).and_return(true)
+          allow(bff_config).to receive(:trusted_proxies).and_return(['10.0.0.0/8'])
+
+          expect(railtie.send(:bff_configuration_valid?)).to be true
+        end
+      end
+
+      context 'when trusted_proxies is an empty Array' do
+        it 'returns false' do
+          allow(bff_config).to receive(:respond_to?).with(:trusted_proxies).and_return(true)
+          allow(bff_config).to receive(:trusted_proxies).and_return([])
+
+          expect(railtie.send(:bff_configuration_valid?)).to be false
+        end
+      end
+
+      context 'when trusted_proxies is nil' do
+        it 'returns false' do
+          allow(bff_config).to receive(:respond_to?).with(:trusted_proxies).and_return(true)
+          allow(bff_config).to receive(:trusted_proxies).and_return(nil)
+
+          expect(railtie.send(:bff_configuration_valid?)).to be false
+        end
+      end
+
+      context 'when trusted_proxies is not an Array' do
+        it 'returns false for Set' do
+          allow(bff_config).to receive(:respond_to?).with(:trusted_proxies).and_return(true)
+          allow(bff_config).to receive(:trusted_proxies).and_return(Set.new(['10.0.0.0/8']))
+
+          expect(railtie.send(:bff_configuration_valid?)).to be false
+        end
+
+        it 'returns false for String' do
+          allow(bff_config).to receive(:respond_to?).with(:trusted_proxies).and_return(true)
+          allow(bff_config).to receive(:trusted_proxies).and_return('10.0.0.0/8')
+
+          expect(railtie.send(:bff_configuration_valid?)).to be false
+        end
+      end
+    end
+  end
+
+  describe '.configure_bff_guard with bff_configuration_valid? integration' do
+    let(:railtie) { described_class }
+    let(:middleware_stack) { double('MiddlewareStack') }
+    let(:bff_config) { double('BffConfig') }
+
+    before do
+      Verikloak::Rails.reset!
+      stub_const('::Verikloak::BFF', Module.new)
+      stub_const('::Verikloak::BFF::HeaderGuard', Class.new)
+      allow(::Verikloak::BFF).to receive(:respond_to?).and_return(false)
+      allow(::Verikloak::BFF).to receive(:respond_to?).with(:config).and_return(true)
+      allow(::Verikloak::BFF).to receive(:respond_to?).with(:config, true).and_return(true)
+      allow(::Verikloak::BFF).to receive(:config).and_return(bff_config)
+
+      Verikloak::Rails.configure do |config|
+        config.auto_insert_bff_header_guard = true
+      end
+    end
+
+    context 'when trusted_proxies is not configured' do
+      before do
+        allow(bff_config).to receive(:respond_to?).with(:disabled).and_return(true)
+        allow(bff_config).to receive(:disabled).and_return(false)
+        allow(bff_config).to receive(:respond_to?).with(:trusted_proxies).and_return(true)
+        allow(bff_config).to receive(:trusted_proxies).and_return([])
+      end
+
+      it 'skips HeaderGuard insertion and logs warning' do
+        expect(middleware_stack).not_to receive(:insert_before)
+        expect(middleware_stack).not_to receive(:insert_after)
+
+        expect(railtie).to receive(:warn_with_fallback).with(
+          '[verikloak] Skipping BFF::HeaderGuard insertion: trusted_proxies not configured. ' \
+          'Set trusted_proxies in bff_header_guard_options to enable header validation.'
+        )
+
+        railtie.send(:configure_bff_guard, middleware_stack)
+      end
+    end
+
+    context 'when disabled is true' do
+      before do
+        allow(bff_config).to receive(:respond_to?).with(:disabled).and_return(true)
+        allow(bff_config).to receive(:disabled).and_return(true)
+      end
+
+      it 'inserts HeaderGuard (internally disabled)' do
+        expect(middleware_stack).to receive(:insert_before)
+          .with(::Verikloak::Middleware, ::Verikloak::BFF::HeaderGuard)
+
+        railtie.send(:configure_bff_guard, middleware_stack)
+      end
+    end
+
+    context 'when trusted_proxies is configured' do
+      before do
+        allow(bff_config).to receive(:respond_to?).with(:disabled).and_return(true)
+        allow(bff_config).to receive(:disabled).and_return(false)
+        allow(bff_config).to receive(:respond_to?).with(:trusted_proxies).and_return(true)
+        allow(bff_config).to receive(:trusted_proxies).and_return(['10.0.0.0/8'])
+      end
+
+      it 'inserts HeaderGuard' do
+        expect(middleware_stack).to receive(:insert_before)
+          .with(::Verikloak::Middleware, ::Verikloak::BFF::HeaderGuard)
+
+        railtie.send(:configure_bff_guard, middleware_stack)
+      end
+    end
+  end
+
   describe 'verikloak.controller initializer' do
     describe 'API mode support' do
       it 'registers hooks for both ActionController::Base and ActionController::API' do


### PR DESCRIPTION
### Changed
- **BFF HeaderGuard safe insertion**: Railtie now validates BFF configuration before inserting `HeaderGuard`. If `trusted_proxies` is not configured (and `disabled` is not set to `true`), insertion is skipped with a warning instead of raising an error.
  - This allows applications to start during initial setup before BFF configuration is complete.
  - A clear warning message guides users to either configure `trusted_proxies` or set `disabled: true`.

### Added
- `bff_configuration_valid?` helper method in Railtie to check BFF configuration validity.