### PR TITLE
Update libs and logics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.4.0] - 2026-02-15
+
+### Security
+- **Header sanitization**: `ErrorRenderer` now delegates to `Verikloak::ErrorResponse.sanitize_header_value` — strips all control characters (`[[:cntrl:]]`), not just CR/LF, consistent with core gem
+- **Request-ID sanitization**: Log tag builder strengthened from `/[\r\n]+/` to `/[[:cntrl:]]+/` to block all control characters in tagged logging
+- **BFF configurator hardening**: `public_send` in `BffConfigurator` is now guarded with a whitelist — rejects keys starting with `_` or containing `!` to prevent accidental invocation of non-accessor methods
+
+### Fixed
+- **`with_required_audience!`**: Was passing two positional arguments to `Error.new` (`'forbidden', 'message'`), which raises `ArgumentError` with core gem 0.4.0's keyword-arg signature. Now uses `Error.new('Required audience not satisfied', code: 'forbidden')`
+- **`authenticate_user!`**: Was passing `Error.new('unauthorized')` which set `code` to `nil` (message became `'unauthorized'` but code was unset). Now uses `Error.new('Unauthorized', code: 'unauthorized')` for correct error rendering
+- Test stubs updated to match core gem's keyword-arg `Error.new(message, code:, http_status:)` signature
+
+### Added
+- `allow_http` configuration option — forwarded to core `Verikloak::Middleware` for development/test environments where HTTPS is unavailable
+- Logger cycle detection using `Set` guard in `_verikloak_base_logger` to prevent infinite loops with circular logger chains
+
+### Changed
+- **BREAKING**: Minimum `verikloak` dependency raised to `>= 0.4.0` (keyword-arg `Error.new` signature)
+- Dev dependency `rspec` pinned to `~> 3.13`, `rubocop-rspec` pinned to `~> 3.9`
+- Extracted `auto_disable_rescue_pundit` method from `apply_configuration` in Railtie for clarity and testability
+- Removed `sanitize_quoted` private method from `ErrorRenderer` in favor of shared `Verikloak::ErrorResponse.sanitize_header_value`
+
+---
+
 ## [0.3.2] - 2026-01-01
 
 ### Changed

--- a/Gemfile
+++ b/Gemfile
@@ -8,10 +8,10 @@ gemspec
 group :development, :test do
   gem 'rack-test'
   gem 'rake'
-  gem 'rspec'
+  gem 'rspec', '~> 3.13'
   gem 'rubocop', require: false
   gem 'rubocop-rake', require: false
-  gem 'rubocop-rspec', require: false
+  gem 'rubocop-rspec', '~> 3.9', require: false
 end
 
 # Security auditing for dependencies in development/CI

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 PATH
   remote: .
   specs:
-    verikloak-rails (0.3.2)
+    verikloak-rails (0.4.0)
       rack (>= 2.2, < 4.0)
       rails (>= 6.1, < 9.0)
-      verikloak (>= 0.3.0, < 1.0.0)
+      verikloak (>= 0.4.0, < 1.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -85,8 +85,8 @@ GEM
     benchmark (0.4.1)
     bigdecimal (3.2.3)
     builder (3.3.0)
-    bundler-audit (0.9.2)
-      bundler (>= 1.2.0, < 3)
+    bundler-audit (0.9.3)
+      bundler (>= 1.2.0)
       thor (~> 1.0)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.4)
@@ -97,13 +97,13 @@ GEM
     drb (2.2.3)
     erb (5.0.2)
     erubi (1.13.1)
-    faraday (2.14.0)
+    faraday (2.14.1)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
     faraday-net_http (3.4.1)
       net-http (>= 0.5.0)
-    faraday-retry (2.3.2)
+    faraday-retry (2.4.0)
       faraday (~> 2.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
@@ -114,7 +114,7 @@ GEM
       pp (>= 0.6.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    json (2.16.0)
+    json (2.18.1)
     jwt (3.1.2)
       base64
     language_server-protocol (3.17.0.5)
@@ -150,13 +150,13 @@ GEM
     nokogiri (1.18.9-x86_64-linux-musl)
       racc (~> 1.4)
     parallel (1.27.0)
-    parser (3.3.10.0)
+    parser (3.3.10.1)
       ast (~> 2.4.1)
       racc
     pp (0.6.2)
       prettyprint
     prettyprint (0.2.0)
-    prism (1.6.0)
+    prism (1.9.0)
     psych (5.2.6)
       date
       stringio
@@ -221,7 +221,7 @@ GEM
     rspec-support (3.13.6)
     rspec_junit_formatter (0.6.0)
       rspec-core (>= 2, < 4, != 2.12.0)
-    rubocop (1.81.7)
+    rubocop (1.84.2)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -229,18 +229,18 @@ GEM
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 2.9.3, < 3.0)
-      rubocop-ast (>= 1.47.1, < 2.0)
+      rubocop-ast (>= 1.49.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.48.0)
+    rubocop-ast (1.49.0)
       parser (>= 3.3.7.2)
-      prism (~> 1.4)
+      prism (~> 1.7)
     rubocop-rake (0.7.1)
       lint_roller (~> 1.1)
       rubocop (>= 1.72.1)
-    rubocop-rspec (3.7.0)
+    rubocop-rspec (3.9.0)
       lint_roller (~> 1.1)
-      rubocop (~> 1.72, >= 1.72.1)
+      rubocop (~> 1.81)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
     simplecov (0.22.0)
@@ -250,19 +250,19 @@ GEM
     simplecov-html (0.13.2)
     simplecov_json_formatter (0.1.4)
     stringio (3.1.7)
-    thor (1.4.0)
+    thor (1.5.0)
     timeout (0.4.3)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
-    unicode-emoji (4.1.0)
+    unicode-emoji (4.2.0)
     uri (1.0.4)
     useragent (0.16.11)
-    verikloak (0.3.0)
-      faraday (>= 2.0, < 3.0)
-      faraday-retry (>= 2.0, < 3.0)
-      json (~> 2.6)
+    verikloak (0.4.0)
+      faraday (>= 2.14.1, < 3.0)
+      faraday-retry (>= 2.4.0, < 3.0)
+      json (~> 2.18)
       jwt (>= 2.7, < 4.0)
     websocket-driver (0.8.0)
       base64
@@ -279,11 +279,11 @@ DEPENDENCIES
   bundler-audit
   rack-test
   rake
-  rspec
+  rspec (~> 3.13)
   rspec_junit_formatter
   rubocop
   rubocop-rake
-  rubocop-rspec
+  rubocop-rspec (~> 3.9)
   simplecov
   verikloak-rails!
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Provide drop-in, token-based authentication for Rails APIs via Verikloak (OIDC d
 ## Compatibility
 - Ruby: >= 3.1
 - Rails: 6.1 – 8.x
-- verikloak: >= 0.3.0, < 1.0.0
+- verikloak: >= 0.4.0, < 1.0.0
 
 ## Quick Start
 ```bash
@@ -168,6 +168,7 @@ Keys under `config.verikloak`:
 | `token_env_key` | String | Custom Rack env key that stores the Bearer token | `nil` (middleware default `verikloak.token`) |
 | `user_env_key` | String | Custom Rack env key that stores decoded claims | `nil` (middleware default `verikloak.user`) |
 | `bff_header_guard_options` | Hash or Proc | Forwarded to `Verikloak::BFF.configure` prior to middleware insertion | `{}` |
+| `allow_http` | Boolean | Allow `http://` discovery URLs (forwarded to core middleware). **Only for development/test.** | `false` |
 
 Environment variable examples are in the generated initializer.
 
@@ -266,14 +267,15 @@ Rails.application.configure do
 end
 ```
 
-Note: Always sanitize values placed into `WWW-Authenticate` header parameters to avoid header injection. For example:
+Note: Always sanitize values placed into `WWW-Authenticate` header parameters to avoid header injection. You can use the shared helper from the core gem:
 
 ```ruby
 class CompactErrorRenderer
   private
-  def sanitize_quoted(val)
-    # Escape quotes/backslashes and strip CR/LF (collapse runs to a single space)
-    val.to_s.gsub(/(["\\])/) { |m| "\\#{m}" }.gsub(/[\r\n]+/, ' ')
+  def sanitize(val)
+    # Delegates to core gem's sanitizer — escapes quotes/backslashes,
+    # truncates at CRLF, and strips all control characters.
+    Verikloak::ErrorResponse.sanitize_header_value(val)
   end
 end
 ```

--- a/docker/dev.Dockerfile
+++ b/docker/dev.Dockerfile
@@ -33,13 +33,12 @@ RUN bundle install
 # App source
 COPY . .
 
-# Remove build dependencies to slim the image
-RUN apk del .build-deps
-
 # Run as non-root for safety in CI/dev, and match host UID/GID for bind-mount write access
 ARG UID=1000
 ARG GID=1000
 RUN addgroup -S -g $GID app \
     && adduser -S -u $UID -G app app \
-    && chown -R app:app /app
+    && chown -R app:app /app \
+    && chown -R app:app /usr/local/bundle
+
 USER app

--- a/lib/generators/verikloak/install/install_generator.rb
+++ b/lib/generators/verikloak/install/install_generator.rb
@@ -26,7 +26,7 @@ module Verikloak
           ✅ verikloak: initializer created.
 
           Next steps:
-          1) Ensure the base gem is installed:   gem 'verikloak', '>= 0.3.0', '< 1.0.0'
+          1) Ensure the base gem is installed:   gem 'verikloak', '>= 0.4.0', '< 1.0.0'
           2) Set discovery_url / audience in config/initializers/verikloak.rb
           3) (Optional) If you disable auto-include, add this line to ApplicationController:
                include Verikloak::Rails::Controller

--- a/lib/verikloak/rails/bff_configurator.rb
+++ b/lib/verikloak/rails/bff_configurator.rb
@@ -103,7 +103,12 @@ module Verikloak
         target.configure do |config|
           entries.each do |key, value|
             writer = "#{key}="
-            config.public_send(writer, value) if config.respond_to?(writer)
+            # Guard: only call known attr_accessor writers to prevent
+            # accidental invocation of arbitrary public methods.
+            next unless config.respond_to?(writer)
+            next if key.to_s.start_with?('_') || key.to_s.include?('!')
+
+            config.public_send(writer, value)
           end
         end
       end

--- a/lib/verikloak/rails/configuration.rb
+++ b/lib/verikloak/rails/configuration.rb
@@ -61,7 +61,8 @@ module Verikloak
                     :auto_insert_bff_header_guard,
                     :bff_header_guard_insert_before, :bff_header_guard_insert_after,
                     :token_verify_options, :decoder_cache_limit,
-                    :token_env_key, :user_env_key, :bff_header_guard_options
+                    :token_env_key, :user_env_key, :bff_header_guard_options,
+                    :allow_http
 
       # Initialize configuration with sensible defaults for Rails apps.
       # @return [void]
@@ -86,6 +87,7 @@ module Verikloak
         @token_env_key = nil
         @user_env_key = nil
         @bff_header_guard_options = {}
+        @allow_http = false
       end
 
       # Options forwarded to the base Verikloak Rack middleware.
@@ -103,7 +105,8 @@ module Verikloak
           token_verify_options: token_verify_options,
           decoder_cache_limit: decoder_cache_limit,
           token_env_key: token_env_key,
-          user_env_key: user_env_key
+          user_env_key: user_env_key,
+          allow_http: allow_http
         }.compact
       end
     end

--- a/lib/verikloak/rails/version.rb
+++ b/lib/verikloak/rails/version.rb
@@ -2,6 +2,6 @@
 
 module Verikloak
   module Rails
-    VERSION = '0.3.2'
+    VERSION = '0.4.0'
   end
 end

--- a/spec/error_renderer_spec.rb
+++ b/spec/error_renderer_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Verikloak::Rails::ErrorRenderer do
   end
 
   it 'renders 401 with WWW-Authenticate for invalid_token' do
-    error = ::Verikloak::Error.new('invalid_token', 'Bad')
+    error = ::Verikloak::Error.new('Bad', code: 'invalid_token')
     renderer.render(controller, error)
 
     expect(controller.rendered[:status]).to eq(401)
@@ -37,7 +37,7 @@ RSpec.describe Verikloak::Rails::ErrorRenderer do
   end
 
   it 'renders 403 for forbidden' do
-    error = ::Verikloak::Error.new('forbidden', 'no')
+    error = ::Verikloak::Error.new('no', code: 'forbidden')
     renderer.render(controller, error)
     expect(controller.rendered[:status]).to eq(403)
     expect(controller.rendered[:json]).to eq(error: 'forbidden', message: 'no')
@@ -51,48 +51,48 @@ RSpec.describe Verikloak::Rails::ErrorRenderer do
   end
 
   it 'maps jwks_fetch_failed to 503 without WWW-Authenticate' do
-    error = ::Verikloak::Error.new('jwks_fetch_failed', 'jwks down')
+    error = ::Verikloak::Error.new('jwks down', code: 'jwks_fetch_failed')
     renderer.render(controller, error)
     expect(controller.rendered[:status]).to eq(503)
     expect(controller.response.headers['WWW-Authenticate']).to be_nil
   end
 
   it 'maps discovery_metadata_invalid to 503 without WWW-Authenticate' do
-    error = ::Verikloak::Error.new('discovery_metadata_invalid', 'bad')
+    error = ::Verikloak::Error.new('bad', code: 'discovery_metadata_invalid')
     renderer.render(controller, error)
     expect(controller.rendered[:status]).to eq(503)
     expect(controller.response.headers['WWW-Authenticate']).to be_nil
   end
 
   it 'sanitizes values in WWW-Authenticate to prevent header injection' do
-    error = ::Verikloak::Error.new('invalid_token', "bad\"\r\ndesc")
+    error = ::Verikloak::Error.new("bad\"\r\ndesc", code: 'invalid_token')
     renderer.render(controller, error)
     hdr = controller.response.headers['WWW-Authenticate']
     expect(hdr).to include('error="invalid_token"')
     # No newlines are allowed in header
     expect(hdr).not_to include("\r")
     expect(hdr).not_to include("\n")
-    # Quote is escaped inside the quoted-string value; CR/LF collapsed to a single space
-    expect(hdr).to include('error_description="bad\\" desc"')
+    # sanitize_header_value truncates at the first CRLF and escapes quotes
+    expect(hdr).to include('error_description="bad\\""')
   end
 
   context 'with edge case inputs' do
     it 'handles nil error message gracefully' do
-      error = ::Verikloak::Error.new('invalid_token', nil)
+      error = ::Verikloak::Error.new(nil, code: 'invalid_token')
       renderer.render(controller, error)
       expect(controller.rendered[:status]).to eq(401)
       expect(controller.rendered[:json][:error]).to eq('invalid_token')
     end
 
     it 'handles empty string error message' do
-      error = ::Verikloak::Error.new('invalid_token', '')
+      error = ::Verikloak::Error.new('', code: 'invalid_token')
       renderer.render(controller, error)
       expect(controller.rendered[:status]).to eq(401)
       expect(controller.rendered[:json][:error]).to eq('invalid_token')
     end
 
     it 'handles unknown error codes as 401' do
-      error = ::Verikloak::Error.new('unknown_code', 'mystery')
+      error = ::Verikloak::Error.new('mystery', code: 'unknown_code')
       renderer.render(controller, error)
       expect(controller.rendered[:status]).to eq(401)
       expect(controller.rendered[:json][:error]).to eq('unknown_code')

--- a/spec/support/verikloak_stubs.rb
+++ b/spec/support/verikloak_stubs.rb
@@ -5,14 +5,16 @@
 
 module ::Verikloak; end unless defined?(::Verikloak)
 
-# Stub for Verikloak::Error - the base error class used throughout verikloak
+# Stub for Verikloak::Error - the base error class used throughout verikloak.
+# Matches the core gem's current signature: Error.new(message, code:, http_status:)
 unless defined?(::Verikloak::Error)
   class ::Verikloak::Error < StandardError
-    attr_reader :code
+    attr_reader :code, :http_status
 
-    def initialize(code = 'unauthorized', message = nil)
+    def initialize(message = nil, code: nil, http_status: nil)
+      super(message)
       @code = code
-      super(message || code)
+      @http_status = http_status
     end
   end
 end

--- a/verikloak-rails.gemspec
+++ b/verikloak-rails.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   # Runtime dependencies
   spec.add_dependency 'rack', '>= 2.2', '< 4.0'
   spec.add_dependency 'rails', '>= 6.1', '< 9.0'
-  spec.add_dependency 'verikloak', '>= 0.3.0', '< 1.0.0'
+  spec.add_dependency 'verikloak', '>= 0.4.0', '< 1.0.0'
   # Metadata for RubyGems
   spec.metadata['source_code_uri'] = spec.homepage
   spec.metadata['changelog_uri']   = "#{spec.homepage}/blob/main/CHANGELOG.md"


### PR DESCRIPTION
### Security
- **Header sanitization**: `ErrorRenderer` now delegates to `Verikloak::ErrorResponse.sanitize_header_value` — strips all control characters (`[[:cntrl:]]`), not just CR/LF, consistent with core gem
- **Request-ID sanitization**: Log tag builder strengthened from `/[\r\n]+/` to `/[[:cntrl:]]+/` to block all control characters in tagged logging
- **BFF configurator hardening**: `public_send` in `BffConfigurator` is now guarded with a whitelist — rejects keys starting with `_` or containing `!` to prevent accidental invocation of non-accessor methods

### Fixed
- **`with_required_audience!`**: Was passing two positional arguments to `Error.new` (`'forbidden', 'message'`), which raises `ArgumentError` with core gem 0.4.0's keyword-arg signature. Now uses `Error.new('Required audience not satisfied', code: 'forbidden')`
- **`authenticate_user!`**: Was passing `Error.new('unauthorized')` which set `code` to `nil` (message became `'unauthorized'` but code was unset). Now uses `Error.new('Unauthorized', code: 'unauthorized')` for correct error rendering
- Test stubs updated to match core gem's keyword-arg `Error.new(message, code:, http_status:)` signature

### Added
- `allow_http` configuration option — forwarded to core `Verikloak::Middleware` for development/test environments where HTTPS is unavailable
- Logger cycle detection using `Set` guard in `_verikloak_base_logger` to prevent infinite loops with circular logger chains

### Changed
- **BREAKING**: Minimum `verikloak` dependency raised to `>= 0.4.0` (keyword-arg `Error.new` signature)
- Dev dependency `rspec` pinned to `~> 3.13`, `rubocop-rspec` pinned to `~> 3.9`
- Extracted `auto_disable_rescue_pundit` method from `apply_configuration` in Railtie for clarity and testability
- Removed `sanitize_quoted` private method from `ErrorRenderer` in favor of shared `Verikloak::ErrorResponse.sanitize_header_value`