### PR TITLE
fix: authenticate_user! now respects skip_paths on framework-internal controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.0.1] - 2026-03-08
+
+### Fixed
+- **`authenticate_user!` ignores `skip_paths` on framework-internal controllers**: When `auto_include_controller` is enabled (default), `before_action :authenticate_user!` was also applied to framework-internal controllers such as `ActiveStorage::BaseController`. Paths skipped by the middleware layer via `skip_paths` still received a 401 from the controller layer. `authenticate_user!` now consults the configured `skip_paths`, ensuring consistent skip behavior across both middleware and controller layers.
+
+### Added
+- `Verikloak::Rails::SkipPathChecker` — standalone wrapper around `Verikloak::SkipPathMatcher` that enables the controller layer to reuse the same skip-path matching logic as the Rack middleware
+- `Configuration#skip_path_matcher` — lazily-built, cached skip-path matcher instance; automatically invalidated when `skip_paths=` is called
+
+---
+
 ## [1.0.0] - 2026-02-15
 
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,11 +143,11 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.4)
-    nokogiri (1.18.9-aarch64-linux-musl)
+    nokogiri (1.19.1-aarch64-linux-musl)
       racc (~> 1.4)
-    nokogiri (1.18.9-arm64-darwin)
+    nokogiri (1.19.1-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.9-x86_64-linux-musl)
+    nokogiri (1.19.1-x86_64-linux-musl)
       racc (~> 1.4)
     parallel (1.27.0)
     parser (3.3.10.1)
@@ -161,7 +161,7 @@ GEM
       date
       stringio
     racc (1.8.1)
-    rack (3.2.4)
+    rack (3.2.5)
     rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    verikloak-rails (1.0.0)
+    verikloak-rails (1.0.1)
       rack (>= 2.2, < 4.0)
       rails (>= 6.1, < 9.0)
       verikloak (~> 1.0)

--- a/lib/verikloak/rails.rb
+++ b/lib/verikloak/rails.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'verikloak/rails/version'
+require 'verikloak/rails/skip_path_checker'
 require 'verikloak/rails/configuration'
 require 'verikloak/rails/error_renderer'
 require 'verikloak/rails/controller'

--- a/lib/verikloak/rails/configuration.rb
+++ b/lib/verikloak/rails/configuration.rb
@@ -54,7 +54,7 @@ module Verikloak
     #   Rack middleware to insert the header guard after.
     #   @return [Object, String, Symbol, nil]
     class Configuration
-      attr_accessor :discovery_url, :audience, :issuer, :leeway, :skip_paths,
+      attr_accessor :discovery_url, :audience, :issuer, :leeway,
                     :logger_tags, :error_renderer, :auto_include_controller,
                     :render_500_json, :rescue_pundit,
                     :middleware_insert_before, :middleware_insert_after,
@@ -63,6 +63,8 @@ module Verikloak
                     :token_verify_options, :decoder_cache_limit,
                     :token_env_key, :user_env_key, :bff_header_guard_options,
                     :allow_http
+
+      attr_reader :skip_paths
 
       # Initialize configuration with sensible defaults for Rails apps.
       # @return [void]
@@ -88,6 +90,19 @@ module Verikloak
         @user_env_key = nil
         @bff_header_guard_options = {}
         @allow_http = false
+        @skip_path_matcher = nil
+      end
+
+      # @param value [Array<String, Regexp>]
+      def skip_paths=(value)
+        @skip_paths = value
+        @skip_path_matcher = nil
+      end
+
+      # Pre-compiled skip-path matcher shared with the controller layer.
+      # @return [Verikloak::Rails::SkipPathChecker]
+      def skip_path_matcher
+        @skip_path_matcher ||= SkipPathChecker.new(skip_paths)
       end
 
       # Options forwarded to the base Verikloak Rack middleware.

--- a/lib/verikloak/rails/configuration.rb
+++ b/lib/verikloak/rails/configuration.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'skip_path_checker'
+
 module Verikloak
   module Rails
     # Configuration for verikloak-rails.
@@ -73,7 +75,7 @@ module Verikloak
         @audience      = 'rails-api'
         @issuer        = nil
         @leeway        = 60
-        @skip_paths    = ['/up', '/health', '/rails/health']
+        @skip_paths    = ['/up', '/health', '/rails/health'].freeze
         @logger_tags    = %i[request_id sub]
         @error_renderer = Verikloak::Rails::ErrorRenderer.new
         @auto_include_controller = true
@@ -95,7 +97,7 @@ module Verikloak
 
       # @param value [Array<String, Regexp>]
       def skip_paths=(value)
-        @skip_paths = value
+        @skip_paths = Array(value).freeze
         @skip_path_matcher = nil
       end
 

--- a/lib/verikloak/rails/controller.rb
+++ b/lib/verikloak/rails/controller.rb
@@ -42,6 +42,7 @@ module Verikloak
       #     before_action :authenticate_user!
       #   end
       def authenticate_user!
+        return if Verikloak::Rails.config.skip_path_matcher.skip?(request.path_info)
         return if authenticated?
 
         e = ::Verikloak::Error.new('Unauthorized', code: 'unauthorized')

--- a/lib/verikloak/rails/skip_path_checker.rb
+++ b/lib/verikloak/rails/skip_path_checker.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'verikloak/skip_path_matcher'
+
+module Verikloak
+  module Rails
+    # Wraps {Verikloak::SkipPathMatcher} into a standalone object so the
+    # controller layer can reuse the same skip-path logic as the Rack middleware.
+    #
+    # @example
+    #   checker = SkipPathChecker.new(['/health', '/public/*'])
+    #   checker.skip?('/health')    #=> true
+    #   checker.skip?('/api/users') #=> false
+    class SkipPathChecker
+      include Verikloak::SkipPathMatcher
+
+      # @param paths [Array<String, Regexp>] skip-path patterns
+      def initialize(paths)
+        compile_skip_paths(Array(paths))
+      end
+
+      public :skip?
+    end
+  end
+end

--- a/lib/verikloak/rails/version.rb
+++ b/lib/verikloak/rails/version.rb
@@ -2,6 +2,6 @@
 
 module Verikloak
   module Rails
-    VERSION = '1.0.0'
+    VERSION = '1.0.1'
   end
 end

--- a/spec/verikloak/rails/controller_spec.rb
+++ b/spec/verikloak/rails/controller_spec.rb
@@ -71,6 +71,70 @@ RSpec.describe Verikloak::Rails::Controller do
     end
   end
 
+  describe '#authenticate_user!' do
+    let(:request) do
+      instance_double('ActionDispatch::Request', env: env, headers: {}, request_id: nil, path_info: request_path)
+    end
+    let(:request_path) { '/api/protected' }
+
+    context 'when the path matches a configured skip_path' do
+      before do
+        Verikloak::Rails.config.skip_paths = ['/rails/active_storage/*', '/health']
+      end
+
+      let(:request_path) { '/rails/active_storage/blobs/proxy/abc123' }
+
+      it 'skips authentication and does not render an error' do
+        controller.authenticate_user!
+        expect(controller.render_calls).to be_empty
+      end
+    end
+
+    context 'when the path exactly matches a skip_path' do
+      before do
+        Verikloak::Rails.config.skip_paths = ['/health']
+      end
+
+      let(:request_path) { '/health' }
+
+      it 'skips authentication' do
+        controller.authenticate_user!
+        expect(controller.render_calls).to be_empty
+      end
+    end
+
+    context 'when the path does not match any skip_path and user is unauthenticated' do
+      before do
+        Verikloak::Rails.config.skip_paths = ['/health']
+      end
+
+      let(:request_path) { '/api/protected' }
+
+      it 'invokes the error renderer' do
+        renderer = instance_double('Verikloak::Rails::ErrorRenderer')
+        allow(renderer).to receive(:render)
+        Verikloak::Rails.config.error_renderer = renderer
+
+        controller.authenticate_user!
+        expect(renderer).to have_received(:render).with(controller, an_instance_of(Verikloak::Error))
+      end
+    end
+
+    context 'when the path does not match any skip_path and user is authenticated' do
+      before do
+        Verikloak::Rails.config.skip_paths = ['/health']
+        env['verikloak.user'] = { 'sub' => 'user-1' }
+      end
+
+      let(:request_path) { '/api/protected' }
+
+      it 'does not render an error' do
+        controller.authenticate_user!
+        expect(controller.render_calls).to be_empty
+      end
+    end
+  end
+
   describe '#_verikloak_log_internal_error' do
     it 'swallows logging failures from the chosen logger' do
       failing_logger = Class.new do


### PR DESCRIPTION
### Fixed
- **`authenticate_user!` ignores `skip_paths` on framework-internal controllers**: When `auto_include_controller` is enabled (default), `before_action :authenticate_user!` was also applied to framework-internal controllers such as `ActiveStorage::BaseController`. Paths skipped by the middleware layer via `skip_paths` still received a 401 from the controller layer. `authenticate_user!` now consults the configured `skip_paths`, ensuring consistent skip behavior across both middleware and controller layers.

### Added
- `Verikloak::Rails::SkipPathChecker` — standalone wrapper around `Verikloak::SkipPathMatcher` that enables the controller layer to reuse the same skip-path matching logic as the Rack middleware
- `Configuration#skip_path_matcher` — lazily-built, cached skip-path matcher instance; automatically invalidated when `skip_paths=` is called