### PR TITLE
Release 1.2.1: fix CI coverage measurement, add Ruby compatibility matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,11 @@ jobs:
         run: docker compose build --pull
 
       - name: Run RSpec with coverage and JUnit output
+        # `-e SIMPLECOV` forwards the step-level env var into the container;
+        # compose does not pass host env vars through on its own.
         run: |
           mkdir -p tmp/coverage tmp/rspec
-          docker compose run --rm -u 0:0 dev \
+          docker compose run --rm -u 0:0 -e SIMPLECOV dev \
             bash -c "bundle exec rspec --format progress --format RspecJunitFormatter --out tmp/rspec/results.xml"
         env:
           SIMPLECOV: true
@@ -65,6 +67,39 @@ jobs:
         with:
           name: rspec-coverage
           path: artifacts/
+
+  compatibility:
+    # Verifies the gemspec's `required_ruby_version >= 3.1` claim on every
+    # supported minor Ruby. The docker-based `rspec` job covers the pinned
+    # development Ruby (3.4); this matrix covers the rest without docker.
+    # Uses gemfiles/compat.gemfile because the main Gemfile.lock pins
+    # Rails 8.1 / zeitwerk 2.7, which require Ruby >= 3.2.
+    name: RSpec (Ruby ${{ matrix.ruby }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    env:
+      BUNDLE_GEMFILE: gemfiles/compat.gemfile
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ['3.1', '3.2', '3.3']
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          persist-credentials: false
+
+      - name: Set up Ruby ${{ matrix.ruby }}
+        uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+
+      - name: Run RSpec
+        run: bundle exec rspec --format progress
 
   contracts:
     name: Sibling gem contracts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- **CI coverage was silently never measured**: the RSpec step set `SIMPLECOV: true` as step-level env, but `docker compose run` does not pass host env vars into the container, so `spec_helper` never enabled SimpleCov and the uploaded `rspec-coverage` artifact contained no report. The step now forwards it explicitly (`docker compose run -e SIMPLECOV`), matching verikloak core.
+
+### Added
+- **CI Ruby compatibility matrix (3.1/3.2/3.3)**: a new non-docker `compatibility` job verifies the gemspec's `required_ruby_version >= 3.1` claim on every supported minor Ruby (the docker `rspec` job keeps covering the pinned development Ruby 3.4). It bundles with the new `gemfiles/compat.gemfile` because the main `Gemfile.lock` pins Rails 8.1 / zeitwerk 2.7 (Ruby >= 3.2 only); each matrix Ruby resolves the newest Rails it supports (7.2 on 3.1, 8.1 on 3.2+), so the declared Rails floor gets exercised too.
+
+---
+
 ## [1.2.0] - 2026-07-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [Unreleased]
+## [1.2.1] - 2026-07-03
 
 ### Fixed
 - **CI coverage was silently never measured**: the RSpec step set `SIMPLECOV: true` as step-level env, but `docker compose run` does not pass host env vars into the container, so `spec_helper` never enabled SimpleCov and the uploaded `rspec-coverage` artifact contained no report. The step now forwards it explicitly (`docker compose run -e SIMPLECOV`), matching verikloak core.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CI coverage was silently never measured**: the RSpec step set `SIMPLECOV: true` as step-level env, but `docker compose run` does not pass host env vars into the container, so `spec_helper` never enabled SimpleCov and the uploaded `rspec-coverage` artifact contained no report. The step now forwards it explicitly (`docker compose run -e SIMPLECOV`), matching verikloak core.
 
 ### Added
-- **CI Ruby compatibility matrix (3.1/3.2/3.3)**: a new non-docker `compatibility` job verifies the gemspec's `required_ruby_version >= 3.1` claim on every supported minor Ruby (the docker `rspec` job keeps covering the pinned development Ruby 3.4). It bundles with the new `gemfiles/compat.gemfile` because the main `Gemfile.lock` pins Rails 8.1 / zeitwerk 2.7 (Ruby >= 3.2 only); each matrix Ruby resolves the newest Rails it supports (7.2 on 3.1, 8.1 on 3.2+), so the declared Rails floor gets exercised too.
+- **CI Ruby compatibility matrix (3.1/3.2/3.3)**: a new non-docker `compatibility` job verifies the gemspec's `required_ruby_version >= 3.1` claim on every supported minor Ruby (the docker `rspec` job keeps covering the pinned development Ruby 3.4). It bundles with the new `gemfiles/compat.gemfile` because the main `Gemfile.lock` pins Rails 8.1 / zeitwerk 2.7 (Ruby >= 3.2 only); each matrix Ruby resolves the newest Rails it supports (7.2 on 3.1, 8.1 on 3.2+), which also covers a Rails series older than the pinned development one (the declared Rails minimum `>= 6.1` itself is not exercised).
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **CI coverage was silently never measured**: the RSpec step set `SIMPLECOV: true` as step-level env, but `docker compose run` does not pass host env vars into the container, so `spec_helper` never enabled SimpleCov and the uploaded `rspec-coverage` artifact contained no report. The step now forwards it explicitly (`docker compose run -e SIMPLECOV`), matching verikloak core.
+- **Order-dependent spec failures under random ordering**: `spec/integration/rails_integration_spec.rb` could leave custom `user_env_key` / `token_env_key` values on the process-global configuration after its last example, breaking the `Testing::MiddlewareStub` default-key specs when they happened to run next (first caught by the new CI matrix, seed 29776). `spec_helper` now resets the global `Verikloak::Rails` configuration after every example.
 
 ### Added
 - **CI Ruby compatibility matrix (3.1/3.2/3.3)**: a new non-docker `compatibility` job verifies the gemspec's `required_ruby_version >= 3.1` claim on every supported minor Ruby (the docker `rspec` job keeps covering the pinned development Ruby 3.4). It bundles with the new `gemfiles/compat.gemfile` because the main `Gemfile.lock` pins Rails 8.1 / zeitwerk 2.7 (Ruby >= 3.2 only); each matrix Ruby resolves the newest Rails it supports (7.2 on 3.1, 8.1 on 3.2+), which also covers a Rails series older than the pinned development one (the declared Rails minimum `>= 6.1` itself is not exercised).

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    verikloak-rails (1.2.0)
+    verikloak-rails (1.2.1)
       rack (>= 2.2, < 4.0)
       rails (>= 6.1, < 9.0)
       verikloak (~> 1.1)

--- a/gemfiles/compat.gemfile
+++ b/gemfiles/compat.gemfile
@@ -7,7 +7,9 @@
 # Ruby >= 3.2, so it cannot install on every interpreter the gemspec claims
 # via `required_ruby_version >= 3.1`. This file carries only what the unit
 # suite needs and lets each matrix Ruby resolve the newest Rails it supports
-# (7.2 on Ruby 3.1, 8.1 on 3.2+), so the Rails floor gets exercised too.
+# (7.2 on Ruby 3.1, 8.1 on 3.2+), which also covers a Rails series older
+# than the pinned development one. It does not exercise the declared
+# Rails minimum (>= 6.1).
 source 'https://rubygems.org'
 
 gemspec path: '..'

--- a/gemfiles/compat.gemfile
+++ b/gemfiles/compat.gemfile
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# Gemfile for the CI compatibility matrix (Ruby 3.1/3.2/3.3; the docker-based
+# `rspec` job covers the pinned development Ruby 3.4).
+#
+# The main Gemfile.lock pins Rails 8.1 and zeitwerk 2.7, which require
+# Ruby >= 3.2, so it cannot install on every interpreter the gemspec claims
+# via `required_ruby_version >= 3.1`. This file carries only what the unit
+# suite needs and lets each matrix Ruby resolve the newest Rails it supports
+# (7.2 on Ruby 3.1, 8.1 on 3.2+), so the Rails floor gets exercised too.
+source 'https://rubygems.org'
+
+gemspec path: '..'
+
+group :development, :test do
+  gem 'rspec', '~> 3.13'
+end
+
+group :test do
+  gem 'rack-test', '~> 2.1'
+end

--- a/lib/verikloak/rails/version.rb
+++ b/lib/verikloak/rails/version.rb
@@ -2,6 +2,6 @@
 
 module Verikloak
   module Rails
-    VERSION = '1.2.0'
+    VERSION = '1.2.1'
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,6 +36,16 @@ RSpec.configure do |config|
   config.order = :random
   Kernel.srand config.seed
 
+  # Several files mutate the process-global Verikloak::Rails configuration
+  # (custom env keys, render_500_json, ...). Their own before-hooks self-heal
+  # within a file, but whatever the file's last example set would otherwise
+  # leak into the next file under random ordering (e.g. seed 29776 broke the
+  # MiddlewareStub default-key specs). Reset after every example, but only
+  # when the library is loaded — some unit specs run without it.
+  config.after do
+    Verikloak::Rails.reset! if defined?(Verikloak::Rails) && Verikloak::Rails.respond_to?(:reset!)
+  end
+
   # Contract specs (spec/contracts) exercise the REAL sibling gems and must
   # run in a dedicated process so they do not collide with the fakes/stubs
   # used by the unit suite. CI runs them in the "contracts" job:


### PR DESCRIPTION
Releases as **v1.2.1** (development/CI-only; runtime code unchanged from 1.2.0).

## Fixed
- **CI coverage was silently never measured**: the RSpec step set `SIMPLECOV: true` as step-level env, but `docker compose run` does not pass host env vars into the container, so `spec_helper` never enabled SimpleCov and the uploaded `rspec-coverage` artifact contained no report. The step now forwards it explicitly (`docker compose run -e SIMPLECOV`), matching verikloak core.
- **Order-dependent spec failures under random ordering**: `spec/integration/rails_integration_spec.rb` could leave custom `user_env_key` / `token_env_key` values on the process-global configuration after its last example, breaking the `Testing::MiddlewareStub` default-key specs when they happened to run next (first caught by the new CI matrix, seed 29776). `spec_helper` now resets the global `Verikloak::Rails` configuration after every example.

## Added
- **CI Ruby compatibility matrix (3.1/3.2/3.3)**: a new non-docker `compatibility` job verifies the gemspec's `required_ruby_version >= 3.1` claim on every supported minor Ruby (the docker `rspec` job keeps covering the pinned development Ruby 3.4). It bundles with the new `gemfiles/compat.gemfile` because the main `Gemfile.lock` pins Rails 8.1 / zeitwerk 2.7 (Ruby >= 3.2 only); each matrix Ruby resolves the newest Rails it supports (7.2 on 3.1, 8.1 on 3.2+), which also covers a Rails series older than the pinned development one (the declared Rails minimum `>= 6.1` itself is not exercised).

## Notes
- The main-branch required check keeps its exact name (**RSpec**) on the unchanged docker job; the new matrix legs report as `RSpec (Ruby 3.x)`. The `contracts` job is untouched.
- `gemfiles/*.lock` is already gitignored, so the compat lockfile resolved in CI never gets committed.
- Verified locally: the CI command with `-e SIMPLECOV` generates a real coverage report (95.0% line / 69.33% branch, 105 examples, 0 failures) and the downloaded CI `rspec-coverage` artifact matches; RuboCop clean; the unit suite passes on Ruby 3.1.7 with the compat gemfile (Rails 7.2.3.1 / zeitwerk 2.6.18 resolved); the order-dependency fix verified against seed 29776 plus four more seeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)